### PR TITLE
feat: add configurable startup ports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,9 +4,16 @@ playground
 output/
 dist/
 log/
+.gocache/
+.gocache-pr/
+.gomodcache/
+.npm-cache/
+nova-windows-test/
+nova-test.exe
 data/
 web/node_modules/
 web/dist/
+web/pnpm-workspace.yaml
 plan.md
 docs/
 .worktrees/

--- a/README.en.md
+++ b/README.en.md
@@ -122,7 +122,7 @@ export NOVA_BACKEND_PORT="8080"
 export NOVA_FRONTEND_PORT="5173"
 ```
 
-You can also configure models, Agent parameters, editor options, interactive-mode behavior, version management, and interface appearance (language, theme, fonts) in `config.toml`. `theme` supports `dark` (default), `light`, and `system`, and can be saved at the user or workspace level. `NOVA_SKILLS_DIR` / `skills_dir` is the built-in read-only Skills root; custom Skills can be written from the UI to `<nova_dir>/skills` or `<workspace>/.nova/skills`. Configuration precedence:
+You can also configure models, Agent parameters, editor options, interactive-mode behavior, version management, backend/frontend ports, and interface appearance (language, theme, fonts) in `config.toml`. Set the backend port with `backend_port = 8080` and the frontend dev port with `frontend_port = 5173`, or edit them from the user settings page and restart Nova; for one-off launches, `--port` / `--frontend-port` take precedence over `NOVA_BACKEND_PORT` / `NOVA_FRONTEND_PORT` and config files. `theme` supports `dark` (default), `light`, and `system`, and can be saved at the user or workspace level. `NOVA_SKILLS_DIR` / `skills_dir` is the built-in read-only Skills root; custom Skills can be written from the UI to `<nova_dir>/skills` or `<workspace>/.nova/skills`. Configuration precedence:
 
 ```text
 Built-in defaults < global config.toml < user-level config < workspace-level config < environment variables

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ export NOVA_BACKEND_PORT="8080"
 export NOVA_FRONTEND_PORT="5173"
 ```
 
-也可以在 `config.toml` 中配置模型、Agent 参数、编辑器、互动模式、版本管理和界面外观（语言、主题、字体）。`theme` 支持 `dark`（默认）、`light` 和 `system`，可保存到用户级或工作区级配置。`NOVA_SKILLS_DIR` / `skills_dir` 用于内置只读 Skills；自定义 Skills 可通过界面写入 `<nova_dir>/skills` 或 `<workspace>/.nova/skills`。配置优先级：
+也可以在 `config.toml` 中配置模型、Agent 参数、编辑器、互动模式、版本管理、前后端端口和界面外观（语言、主题、字体）。后端端口可写为 `backend_port = 8080`，前端开发端口可写为 `frontend_port = 5173`，也可在设置页的用户配置中修改，重启后生效；临时启动时 `--port` / `--frontend-port` 优先于 `NOVA_BACKEND_PORT` / `NOVA_FRONTEND_PORT` 和配置文件。`theme` 支持 `dark`（默认）、`light` 和 `system`，可保存到用户级或工作区级配置。`NOVA_SKILLS_DIR` / `skills_dir` 用于内置只读 Skills；自定义 Skills 可通过界面写入 `<nova_dir>/skills` 或 `<workspace>/.nova/skills`。配置优先级：
 
 ```text
 内置默认值 < 全局 config.toml < 用户级配置 < 工作区级配置 < 环境变量

--- a/cmd/nova/main.go
+++ b/cmd/nova/main.go
@@ -21,12 +21,15 @@ import (
 func main() {
 	var (
 		workspace string
-		port      = defaultPort()
 		dev       bool
 		noOpen    bool
 	)
+	cfg := config.Load()
+	port := defaultPort(cfg)
+	frontendPort := defaultFrontendPort(cfg)
 	flag.StringVar(&workspace, "workspace", "", "作品工作目录 (默认恢复上次打开的书籍)")
 	flag.StringVar(&port, "port", port, "HTTP 服务端口")
+	flag.StringVar(&frontendPort, "frontend-port", frontendPort, "前端开发服务端口")
 	flag.BoolVar(&dev, "dev", false, "开发模式：同时启动 Vite 前端 dev server")
 	flag.BoolVar(&noOpen, "no-open", false, "启动服务后不自动打开浏览器")
 	flag.Parse()
@@ -37,7 +40,6 @@ func main() {
 	log.Printf("[startup] 日志输出已启用 dir=./log current_file=%s", logPath)
 	port = selectStartupPort(port, shouldAutoPickPort())
 
-	cfg := config.Load()
 	if workspace != "" {
 		cfg.Workspace = workspace
 		cfg.ResumeLastWorkspace = false
@@ -67,17 +69,17 @@ func main() {
 	fmt.Printf("  服务地址: %s\n", url)
 	fmt.Printf("  作品目录: %s\n", application.Workspace())
 	if dev {
-		fmt.Printf("  前端开发: http://localhost:5173\n")
+		fmt.Printf("  前端开发: http://localhost:%s\n", frontendPort)
 	}
 	fmt.Printf("  按 Ctrl+C 停止服务\n\n")
 
 	// 开发模式：同时启动 Vite dev server
 	if dev {
-		go startViteDev()
+		go startViteDev(frontendPort)
 	}
 	if !noOpen {
 		if dev {
-			go openBrowser("http://localhost:5173")
+			go openBrowser(fmt.Sprintf("http://localhost:%s", frontendPort))
 		} else {
 			go openBrowser(url)
 		}
@@ -103,7 +105,7 @@ func openBrowser(url string) {
 }
 
 // startViteDev 启动 Vite 前端开发服务器
-func startViteDev() {
+func startViteDev(port string) {
 	// 查找 web 目录
 	webDir := "./web"
 	if _, err := os.Stat(webDir); os.IsNotExist(err) {
@@ -115,7 +117,7 @@ func startViteDev() {
 		}
 	}
 
-	cmd := exec.Command("pnpm", "dev", "--host", "0.0.0.0")
+	cmd := exec.Command("pnpm", "dev", "--host", "0.0.0.0", "--port", port)
 	cmd.Dir = webDir
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
@@ -124,11 +126,18 @@ func startViteDev() {
 	}
 }
 
-func defaultPort() string {
-	if v := os.Getenv("NOVA_BACKEND_PORT"); v != "" {
-		return v
+func defaultPort(cfg *config.Config) string {
+	if cfg != nil && cfg.BackendPort > 0 {
+		return strconv.Itoa(cfg.BackendPort)
 	}
 	return "8080"
+}
+
+func defaultFrontendPort(cfg *config.Config) string {
+	if cfg != nil && cfg.FrontendPort > 0 {
+		return strconv.Itoa(cfg.FrontendPort)
+	}
+	return "5173"
 }
 
 func shouldAutoPickPort() bool {

--- a/config.toml
+++ b/config.toml
@@ -67,6 +67,10 @@ openai_model = "deepseek-v4-pro"
 skills_dir = "./skills"
 nova_dir = "./.nova"
 
+# 修改端口号
+backend_port = 8080
+frontend_port = 8081
+
 # 编辑器
 auto_save_enabled = true
 auto_save_interval_ms = 1500

--- a/config/config.go
+++ b/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"strconv"
 
 	toml "github.com/pelletier/go-toml/v2"
 )
@@ -18,6 +19,8 @@ type Config struct {
 	AgentPrompts                AgentPromptSettings    `toml:"agent_prompts"`
 	AgentSkills                 AgentSkillSettings     `toml:"agent_skills"`
 	SkillsDir                   string                 `toml:"skills_dir"`
+	BackendPort                 int                    `toml:"backend_port"`
+	FrontendPort                int                    `toml:"frontend_port"`
 	NovaDir                     string                 `toml:"nova_dir"`
 	Workspace                   string                 `toml:"workspace"`
 	IDEStoryTellerID            string                 `toml:"-"`
@@ -72,6 +75,8 @@ func LoadWithWorkspace(workspace string) (*Config, LayeredSettings, error) {
 		AgentPrompts:                s.AgentPrompts,
 		AgentSkills:                 s.AgentSkills,
 		SkillsDir:                   s.SkillsDir,
+		BackendPort:                 settingsInt(s.BackendPort, 8080),
+		FrontendPort:                settingsInt(s.FrontendPort, 5173),
 		NovaDir:                     novaDir,
 		Workspace:                   workspace,
 		IDEStoryTellerID:            s.IDEStoryTellerID,
@@ -144,6 +149,12 @@ func settingsFromConfig(cfg *Config) Settings {
 		ChapterFilenameFormat: cfg.ChapterFilenameFormat,
 		VolumeDirFormat:       cfg.VolumeDirFormat,
 	}
+	if cfg.BackendPort > 0 {
+		settings.BackendPort = &cfg.BackendPort
+	}
+	if cfg.FrontendPort > 0 {
+		settings.FrontendPort = &cfg.FrontendPort
+	}
 	if cfg.MaxIteration > 0 {
 		settings.MaxIteration = &cfg.MaxIteration
 	}
@@ -176,6 +187,8 @@ func Load() *Config {
 			AgentPrompts:                d.AgentPrompts,
 			AgentSkills:                 d.AgentSkills,
 			SkillsDir:                   d.SkillsDir,
+			BackendPort:                 settingsInt(d.BackendPort, 8080),
+			FrontendPort:                settingsInt(d.FrontendPort, 5173),
 			NovaDir:                     normalizePath(d.NovaDir),
 			IDEStoryTellerID:            d.IDEStoryTellerID,
 			MaxIteration:                settingsInt(d.MaxIteration, 50),
@@ -255,6 +268,16 @@ func overrideFromEnv(cfg *Config) {
 	}
 	if v := os.Getenv("NOVA_WORKSPACE"); v != "" {
 		cfg.Workspace = v
+	}
+	if v := os.Getenv("NOVA_BACKEND_PORT"); v != "" {
+		if port, err := strconv.Atoi(v); err == nil && port >= 1 && port <= 65535 {
+			cfg.BackendPort = port
+		}
+	}
+	if v := os.Getenv("NOVA_FRONTEND_PORT"); v != "" {
+		if port, err := strconv.Atoi(v); err == nil && port >= 1 && port <= 65535 {
+			cfg.FrontendPort = port
+		}
 	}
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -142,3 +142,52 @@ func TestLoadWithWorkspaceUsesGlobalConfigAsBaseLayer(t *testing.T) {
 		t.Fatalf("global layer should be exposed: %s", layered.Global.OpenAIModel)
 	}
 }
+
+func TestLoadWithWorkspaceUsesConfiguredStartupPorts(t *testing.T) {
+	root := t.TempDir()
+	t.Chdir(root)
+	ws := t.TempDir()
+	t.Setenv("NOVA_DIR", "")
+	t.Setenv("NOVA_BACKEND_PORT", "")
+
+	if err := os.WriteFile(filepath.Join(root, "config.toml"), []byte("backend_port = 18080\nfrontend_port = 15173\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, layered, err := LoadWithWorkspace(ws)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.BackendPort != 18080 {
+		t.Fatalf("global backend_port should be effective: %d", cfg.BackendPort)
+	}
+	if layered.Effective.BackendPort == nil || *layered.Effective.BackendPort != 18080 {
+		t.Fatalf("effective backend_port should be exposed")
+	}
+	if cfg.FrontendPort != 15173 {
+		t.Fatalf("global frontend_port should be effective: %d", cfg.FrontendPort)
+	}
+	if layered.Effective.FrontendPort == nil || *layered.Effective.FrontendPort != 15173 {
+		t.Fatalf("effective frontend_port should be exposed")
+	}
+}
+
+func TestLoadStartupPortEnvOverridesConfig(t *testing.T) {
+	root := t.TempDir()
+	t.Chdir(root)
+	t.Setenv("NOVA_DIR", "")
+	t.Setenv("NOVA_BACKEND_PORT", "19090")
+	t.Setenv("NOVA_FRONTEND_PORT", "16173")
+
+	if err := os.WriteFile(filepath.Join(root, "config.toml"), []byte("backend_port = 18080\nfrontend_port = 15173\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := Load()
+	if cfg.BackendPort != 19090 {
+		t.Fatalf("NOVA_BACKEND_PORT should override config: %d", cfg.BackendPort)
+	}
+	if cfg.FrontendPort != 16173 {
+		t.Fatalf("NOVA_FRONTEND_PORT should override config: %d", cfg.FrontendPort)
+	}
+}

--- a/config/settings.go
+++ b/config/settings.go
@@ -22,8 +22,10 @@ type Settings struct {
 	AgentSkills   AgentSkillSettings     `toml:"agent_skills,omitempty" json:"agent_skills,omitempty"`
 
 	// 路径
-	SkillsDir string `toml:"skills_dir,omitempty" json:"skills_dir,omitempty"`
-	NovaDir   string `toml:"nova_dir,omitempty" json:"nova_dir,omitempty"`
+	SkillsDir    string `toml:"skills_dir,omitempty" json:"skills_dir,omitempty"`
+	NovaDir      string `toml:"nova_dir,omitempty" json:"nova_dir,omitempty"`
+	BackendPort  *int   `toml:"backend_port,omitempty" json:"backend_port,omitempty"`
+	FrontendPort *int   `toml:"frontend_port,omitempty" json:"frontend_port,omitempty"`
 
 	// 编辑器
 	AutoSaveEnabled             *bool  `toml:"auto_save_enabled,omitempty" json:"auto_save_enabled,omitempty"`
@@ -72,6 +74,8 @@ func DefaultSettings() Settings {
 		OpenAIModel:                 "deepseek-v4-pro",
 		SkillsDir:                   "./skills",
 		NovaDir:                     "./.nova",
+		BackendPort:                 intPtr(8080),
+		FrontendPort:                intPtr(5173),
 		AutoSaveEnabled:             boolPtr(true),
 		AutoSaveIntervalMs:          intPtr(1500),
 		ChapterFilenameFormat:       "ch{order:05}-{chapter}-{title}.md",
@@ -131,6 +135,12 @@ func Merge(parent, child Settings) Settings {
 	}
 	if child.NovaDir != "" {
 		out.NovaDir = child.NovaDir
+	}
+	if child.BackendPort != nil {
+		out.BackendPort = child.BackendPort
+	}
+	if child.FrontendPort != nil {
+		out.FrontendPort = child.FrontendPort
 	}
 	if child.AutoSaveEnabled != nil {
 		out.AutoSaveEnabled = child.AutoSaveEnabled
@@ -305,6 +315,10 @@ func LoadLayeredWithGlobal(novaDir, workspace string, global Settings) (LayeredS
 		if err != nil {
 			return LayeredSettings{}, err
 		}
+		// Startup ports are decided before a workspace is opened, so workspace-level
+		// files must not override them.
+		ws.BackendPort = nil
+		ws.FrontendPort = nil
 	}
 	def := DefaultSettings()
 	def.NovaDir = novaDir
@@ -331,11 +345,23 @@ func LoadLayeredWithGlobal(novaDir, workspace string, global Settings) (LayeredS
 func sanitizeEditableSettings(s Settings) Settings {
 	// nova_dir 是启动级定位参数，不能由用户级/工作区级配置反向修改自身位置。
 	s.NovaDir = ""
+	s.BackendPort = normalizePort(s.BackendPort)
+	s.FrontendPort = normalizePort(s.FrontendPort)
 	s.Language = normalizeLanguage(s.Language)
 	s.Theme = normalizeTheme(s.Theme)
 	s.MotionIntensity = normalizeMotionIntensity(s.MotionIntensity)
 	s.AgentPrompts = sanitizeAgentPromptSettings(s.AgentPrompts)
 	return s
+}
+
+func normalizePort(port *int) *int {
+	if port == nil {
+		return nil
+	}
+	if *port < 1 || *port > 65535 {
+		return nil
+	}
+	return port
 }
 
 func normalizeLanguage(language string) string {

--- a/config/settings_test.go
+++ b/config/settings_test.go
@@ -60,6 +60,12 @@ func TestDefaultSettingsValues(t *testing.T) {
 	if s.MotionIntensity != "system" {
 		t.Fatalf("MotionIntensity default: %s", s.MotionIntensity)
 	}
+	if s.BackendPort == nil || *s.BackendPort != 8080 {
+		t.Fatalf("BackendPort default")
+	}
+	if s.FrontendPort == nil || *s.FrontendPort != 5173 {
+		t.Fatalf("FrontendPort default")
+	}
 }
 
 func TestMergeOverridesNonZero(t *testing.T) {
@@ -76,6 +82,8 @@ func TestMergeOverridesNonZero(t *testing.T) {
 		MotionIntensity:            "system",
 		ChapterFilenameFormat:      "old-chapter",
 		VolumeDirFormat:            "old-volume",
+		BackendPort:                intPtr(8080),
+		FrontendPort:               intPtr(5173),
 		InteractiveMaxTokens:       intPtr(0),
 		InteractiveHotChoices:      boolPtr(true),
 		InteractiveStageFontSize:   intPtr(16),
@@ -93,6 +101,8 @@ func TestMergeOverridesNonZero(t *testing.T) {
 		MotionIntensity:            "reduced",
 		ChapterFilenameFormat:      "new-chapter",
 		VolumeDirFormat:            "new-volume",
+		BackendPort:                intPtr(18080),
+		FrontendPort:               intPtr(15173),
 		InteractiveMaxTokens:       intPtr(4000),
 		InteractiveHotChoices:      boolPtr(false),
 		InteractiveStageFontSize:   intPtr(18),
@@ -131,6 +141,12 @@ func TestMergeOverridesNonZero(t *testing.T) {
 	}
 	if out.ChapterFilenameFormat != "new-chapter" || out.VolumeDirFormat != "new-volume" {
 		t.Fatalf("filename formats should override parent: %#v", out)
+	}
+	if out.BackendPort == nil || *out.BackendPort != 18080 {
+		t.Fatalf("BackendPort should override parent")
+	}
+	if out.FrontendPort == nil || *out.FrontendPort != 15173 {
+		t.Fatalf("FrontendPort should override parent")
 	}
 	if out.InteractiveMaxTokens == nil || *out.InteractiveMaxTokens != 4000 {
 		t.Fatalf("InteractiveMaxTokens should override parent")
@@ -254,6 +270,38 @@ func TestWriteSettingsFileFiltersNovaDir(t *testing.T) {
 	}
 }
 
+func TestWriteSettingsFileFiltersInvalidBackendPort(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "config.toml")
+	in := Settings{OpenAIModel: "abc", BackendPort: intPtr(70000)}
+	if err := WriteSettingsFile(p, in); err != nil {
+		t.Fatal(err)
+	}
+	out, err := ReadSettingsFile(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.BackendPort != nil {
+		t.Fatalf("invalid backend_port should be filtered: %v", *out.BackendPort)
+	}
+}
+
+func TestWriteSettingsFileFiltersInvalidFrontendPort(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "config.toml")
+	in := Settings{OpenAIModel: "abc", FrontendPort: intPtr(70000)}
+	if err := WriteSettingsFile(p, in); err != nil {
+		t.Fatal(err)
+	}
+	out, err := ReadSettingsFile(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.FrontendPort != nil {
+		t.Fatalf("invalid frontend_port should be filtered: %v", *out.FrontendPort)
+	}
+}
+
 func TestLoadLayeredAppliesAllLayers(t *testing.T) {
 	home := t.TempDir()
 	ws := t.TempDir()
@@ -310,5 +358,36 @@ func TestLoadLayeredIgnoresNovaDirFromEditableLayers(t *testing.T) {
 	}
 	if layered.Effective.OpenAIModel != "ws-model" {
 		t.Fatalf("other editable fields should still merge: %q", layered.Effective.OpenAIModel)
+	}
+}
+
+func TestLoadLayeredIgnoresStartupPortsFromWorkspaceLayer(t *testing.T) {
+	home := t.TempDir()
+	ws := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(ws, ".nova"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteSettingsFile(filepath.Join(home, "config.toml"), Settings{BackendPort: intPtr(18080), FrontendPort: intPtr(15173)}); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(ws, ".nova", "config.toml"), []byte("backend_port = 19090\nfrontend_port = 16173\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	layered, err := LoadLayered(home, ws)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if layered.Workspace.BackendPort != nil {
+		t.Fatalf("workspace backend_port should be filtered")
+	}
+	if layered.Workspace.FrontendPort != nil {
+		t.Fatalf("workspace frontend_port should be filtered")
+	}
+	if layered.Effective.BackendPort == nil || *layered.Effective.BackendPort != 18080 {
+		t.Fatalf("user backend_port should remain effective")
+	}
+	if layered.Effective.FrontendPort == nil || *layered.Effective.FrontendPort != 15173 {
+		t.Fatalf("user frontend_port should remain effective")
 	}
 }

--- a/internal/app/runtime_manager.go
+++ b/internal/app/runtime_manager.go
@@ -504,6 +504,12 @@ func applyLayeredSettingsToConfig(cfg *config.Config, layered config.LayeredSett
 	if cfg.NovaDir == "" && layered.Paths.NovaDir != "" {
 		cfg.NovaDir = layered.Paths.NovaDir
 	}
+	if effective.BackendPort != nil {
+		cfg.BackendPort = appSettingsInt(effective.BackendPort, 8080)
+	}
+	if effective.FrontendPort != nil {
+		cfg.FrontendPort = appSettingsInt(effective.FrontendPort, 5173)
+	}
 	if cfg.IDEStoryTellerID == "" && effective.IDEStoryTellerID != "" {
 		cfg.IDEStoryTellerID = effective.IDEStoryTellerID
 	}

--- a/web/src/features/settings/SettingsView.tsx
+++ b/web/src/features/settings/SettingsView.tsx
@@ -184,6 +184,20 @@ export function SettingsView({ onClose }: { onClose?: () => void }) {
         <>
           <Text label={t('settings.paths.skillsDir')} value={draft.skills_dir} placeholder={placeholderFor('skills_dir')}
                 onChange={(v) => setField('skills_dir', v)} />
+          {activeLayer === 'user' && (
+            <>
+              <Num label={t('settings.paths.backendPort')} value={draft.backend_port ?? null}
+                   placeholder={placeholderFor('backend_port')}
+                   min={1}
+                   max={65535}
+                   onChange={(v) => setField('backend_port', v)} />
+              <Num label={t('settings.paths.frontendPort')} value={draft.frontend_port ?? null}
+                   placeholder={placeholderFor('frontend_port')}
+                   min={1}
+                   max={65535}
+                   onChange={(v) => setField('frontend_port', v)} />
+            </>
+          )}
           <ReadOnly label={t('settings.paths.novaDir')} value={layered?.paths?.nova_dir} />
           <ReadOnly label={t('settings.paths.userConfig')} value={layered?.paths?.user_config} />
           <ReadOnly label={t('settings.paths.workspaceConfig')} value={layered?.paths?.workspace_config} />

--- a/web/src/features/settings/types.ts
+++ b/web/src/features/settings/types.ts
@@ -8,6 +8,8 @@ export interface Settings {
   agent_prompts?: AgentPromptSettings
   agent_skills?: AgentSkillSettings
   skills_dir?: string
+  backend_port?: number | null
+  frontend_port?: number | null
   auto_save_enabled?: boolean | null
   auto_save_interval_ms?: number | null
   chapter_filename_format?: string

--- a/web/src/i18n/locales/en-US/settings.ts
+++ b/web/src/i18n/locales/en-US/settings.ts
@@ -55,6 +55,8 @@ const settings = {
   'settings.model.addProfile': 'Add Model',
   'settings.model.deleteProfile': 'Delete model profile',
   'settings.paths.novaDir': 'Nova Data Directory',
+  'settings.paths.backendPort': 'Backend Port (restart required)',
+  'settings.paths.frontendPort': 'Frontend Dev Port (restart required)',
   'settings.paths.skillsDir': 'Skills Directory',
   'settings.paths.userConfig': 'User Config File',
   'settings.paths.workspaceConfig': 'Workspace Config File',

--- a/web/src/i18n/locales/zh-CN/settings.ts
+++ b/web/src/i18n/locales/zh-CN/settings.ts
@@ -55,6 +55,8 @@ const settings = {
   'settings.model.addProfile': '添加模型',
   'settings.model.deleteProfile': '删除模型配置',
   'settings.paths.novaDir': 'Nova 数据目录',
+  'settings.paths.backendPort': '后端端口（重启生效）',
+  'settings.paths.frontendPort': '前端开发端口（重启生效）',
   'settings.paths.skillsDir': 'Skills 目录',
   'settings.paths.userConfig': '用户配置文件',
   'settings.paths.workspaceConfig': '工作区配置文件',


### PR DESCRIPTION
在使用过程中，我发现默认的 8080 和 8081 端口由于较为常见，可能会和本机已有服务发生冲突。虽然现有代码已经可以在端口冲突时自动选择新的可用端口，但支持用户手动配置启动端口会更加灵活。

修改包括：

* 支持自定义前端启动端口
* 支持自定义后端启动端口
* 在设置页面中新增相关配置项
* 更新相关配置读取逻辑、测试和文档
