### PR TITLE
[codex] Respect IME composition before sending inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- 修复豆包等输入法/语音输入仍在组合或后处理文字时，Agent 和互动输入框按 Enter 会误发送未定稿文本的问题。
 - 修复配置管理 Agent 在自动化、资料库、故事记忆、叙事编排和 Skills 等不同配置入口之间共用同一段对话历史的问题；现在会按入口和目标资源隔离历史与 `/clear`。
 - 修复写作 Agent 上下文分析器会按作品状态 Markdown 小标题误拆来源的问题；现在作品状态按创作灵感、状态文件、章节目录、资料库和章节组细纲等真实来源展示。
 - 修复上下文压缩运行时同时出现压缩卡片和 activity 卡片的问题；现在 IDE 与互动故事只保留一个简洁压缩卡片，并用旋转 Loading 表示进行中状态。

--- a/web/src/components/Chat/InputArea.tsx
+++ b/web/src/components/Chat/InputArea.tsx
@@ -26,6 +26,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
+import { isComposingKeyboardEvent } from '@/lib/keyboard'
 
 /** 可用命令列表 */
 const COMMANDS: Array<{ cmd: string; descKey: string; hintKey: string; icon: LucideIcon }> = [
@@ -235,6 +236,7 @@ export function InputArea({
 
     // Enter 发送
     if (e.key === 'Enter' && !e.shiftKey) {
+      if (isComposingKeyboardEvent(e)) return
       e.preventDefault()
       if (canPickCommand) {
         selectCommand(filteredCommands[activeCommandIndex]?.cmd || filteredCommands[0].cmd)

--- a/web/src/features/interactive/components/StoryStage.tsx
+++ b/web/src/features/interactive/components/StoryStage.tsx
@@ -21,6 +21,7 @@ import { buildContextCompactionMessage, createContextCompactionMessageId, upsert
 import { subAgentSessionKey } from '@/components/Chat/subagent-session'
 import { MOBILE_NAVIGATION_OPEN_EVENT } from '@/components/layout/workspace-mobile-layout'
 import type { ChatMessage, ContextAnalysis } from '@/lib/api'
+import { isComposingKeyboardEvent } from '@/lib/keyboard'
 import { fetchSettings } from '@/features/settings/api'
 import { useSkillCommands } from '@/hooks/useSkillCommands'
 import { abortInteractiveChat, analyzeInteractiveContext, compactInteractiveContext, generateInteractiveHotChoices, removeInteractiveContextCompaction, sendInteractiveMessage, switchInteractiveTurnVersion } from '../api'
@@ -1078,6 +1079,7 @@ export function StoryStage({ workspace, styleSceneSuggestions = [], stories = []
                       return
                     }
                     if (event.key === 'Enter' && !event.shiftKey) {
+                      if (isComposingKeyboardEvent(event)) return
                       event.preventDefault()
                       if (canPickSkill) {
                         selectSkillCommand(filteredSkillCommands[activeSkillCommandIndex]?.name || filteredSkillCommands[0].name)

--- a/web/src/lib/keyboard.test.ts
+++ b/web/src/lib/keyboard.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { isEditableTarget, isNativeTextEditingShortcut } from './keyboard'
+import { isComposingKeyboardEvent, isEditableTarget, isNativeTextEditingShortcut } from './keyboard'
 
 describe('keyboard helpers', () => {
   it('识别表单和 contenteditable 输入态', () => {
@@ -25,5 +25,13 @@ describe('keyboard helpers', () => {
     expect(isNativeTextEditingShortcut({ key: 'V', metaKey: false, ctrlKey: true, altKey: false })).toBe(true)
     expect(isNativeTextEditingShortcut({ key: 'k', metaKey: true, ctrlKey: false, altKey: false })).toBe(false)
     expect(isNativeTextEditingShortcut({ key: 'a', metaKey: true, ctrlKey: false, altKey: true })).toBe(false)
+  })
+
+  it('识别输入法组合态按键事件', () => {
+    expect(isComposingKeyboardEvent({ isComposing: true })).toBe(true)
+    expect(isComposingKeyboardEvent({ nativeEvent: { isComposing: true } })).toBe(true)
+    expect(isComposingKeyboardEvent({ keyCode: 229 })).toBe(true)
+    expect(isComposingKeyboardEvent({ nativeEvent: { keyCode: 229 } })).toBe(true)
+    expect(isComposingKeyboardEvent({ keyCode: 13 })).toBe(false)
   })
 })

--- a/web/src/lib/keyboard.ts
+++ b/web/src/lib/keyboard.ts
@@ -7,6 +7,15 @@ interface KeyboardShortcutEvent {
   altKey: boolean
 }
 
+interface ComposingKeyboardEvent {
+  isComposing?: boolean
+  keyCode?: number
+  nativeEvent?: {
+    isComposing?: boolean
+    keyCode?: number
+  }
+}
+
 interface PropagatingKeyboardShortcutEvent extends KeyboardShortcutEvent {
   stopPropagation: () => void
 }
@@ -41,4 +50,9 @@ export function preserveNativeTextEditingShortcut(event: PropagatingKeyboardShor
 export function isSaveShortcut(event: KeyboardShortcutEvent): boolean {
   if (event.altKey || (!event.metaKey && !event.ctrlKey)) return false
   return event.key.toLowerCase() === 's'
+}
+
+/** 判断键盘事件是否仍在输入法组合态，避免 Enter 被误当成发送。 */
+export function isComposingKeyboardEvent(event: ComposingKeyboardEvent): boolean {
+  return Boolean(event.isComposing || event.nativeEvent?.isComposing || event.keyCode === 229 || event.nativeEvent?.keyCode === 229)
 }


### PR DESCRIPTION
## Summary

- Avoid sending Agent and interactive inputs when Enter is pressed during IME composition.
- Apply the guard to Writing Agent, Interactive Story, and Narrative Direction Agent textareas.
- Add regression coverage for composition-aware Enter handling.

## Why

Some input methods and voice-input flows, such as Doubao, keep text in an IME composition/post-processing state before finalizing the textarea value. The current Enter-to-send handlers intercept that Enter event immediately, which can send unfinished text before the input method finishes rewriting it.

## Validation

- `corepack pnpm --store-dir=/Volumes/T9/.cache/nova/pnpm-store test -- InputArea.test.tsx keyboard.test.ts StoryStage.test.tsx SettingPanel.test.tsx --run`
- `git diff --check`
