### PR TITLE
fix: 互动记忆 Agent 超时、记忆面板流丢失、版本回溯丢数据

### DIFF
--- a/internal/app/interactive_conversation.go
+++ b/internal/app/interactive_conversation.go
@@ -630,7 +630,7 @@ type interactiveTurnMemory struct {
 }
 
 const (
-	interactiveStateMemorySchemaBytes = 8 * 1024
+	interactiveStateMemorySchemaBytes = 24 * 1024
 	interactiveStateLoreContextBytes  = 32 * 1024
 )
 

--- a/internal/app/interactive_memory_retry.go
+++ b/internal/app/interactive_memory_retry.go
@@ -5,12 +5,14 @@ import (
 	"fmt"
 	"log"
 	"strings"
+	"time"
 
 	"nova/config"
 	"nova/internal/session"
 )
 
 const interactiveMemoryAgentMaxAttempts = 3
+const interactiveMemoryAgentAttemptTimeout = 2 * time.Minute
 
 type interactiveMemoryOutputGenerator func(context.Context, *config.Config, string) (string, error)
 
@@ -18,7 +20,9 @@ func runInteractiveMemoryAgentWithRetry(ctx context.Context, cfg *config.Config,
 	var lastErr error
 	for attempt := 1; attempt <= interactiveMemoryAgentMaxAttempts; attempt++ {
 		attemptInstruction := interactiveMemoryInstructionForAttempt(instruction, attempt, lastErr)
-		output, err := generate(ctx, cfg, attemptInstruction)
+		attemptCtx, cancel := context.WithTimeout(ctx, interactiveMemoryAgentAttemptTimeout)
+		output, err := generate(attemptCtx, cfg, attemptInstruction)
+		cancel()
 		if err != nil {
 			lastErr = err
 			log.Printf("[interactive-memory-agent] attempt failed phase=generate attempt=%d/%d err=%v", attempt, interactiveMemoryAgentMaxAttempts, err)

--- a/internal/app/interactive_state.go
+++ b/internal/app/interactive_state.go
@@ -11,7 +11,7 @@ import (
 	"nova/internal/session"
 )
 
-const interactiveStateTimeout = 2 * time.Minute
+const interactiveStateTimeout = 5 * time.Minute
 
 func startInteractiveStateTask(cfg *config.Config, conversation *interactiveConversation, turn interactive.TurnEvent, sessionStore *session.Store) {
 	go func() {

--- a/internal/book/versions/files.go
+++ b/internal/book/versions/files.go
@@ -97,7 +97,8 @@ func isTextBytes(data []byte) bool {
 func isVersionExcludedRelPath(relPath string) bool {
 	cleanRel := filepath.ToSlash(filepath.Clean(filepath.FromSlash(relPath)))
 	return cleanRel == ".git" || strings.HasPrefix(cleanRel, ".git/") ||
-		cleanRel == ".nova/runs" || strings.HasPrefix(cleanRel, ".nova/runs/")
+		cleanRel == ".nova/runs" || strings.HasPrefix(cleanRel, ".nova/runs/") ||
+		cleanRel == ".nova/interactive" || strings.HasPrefix(cleanRel, ".nova/interactive/")
 }
 
 func safeVisiblePath(workspace, relPath string) (string, error) {

--- a/internal/book/versions/restore.go
+++ b/internal/book/versions/restore.go
@@ -64,6 +64,13 @@ func (s *Service) removeEmptyVisibleDirs() error {
 	}
 	sort.SliceStable(dirs, func(i, j int) bool { return len(dirs[i]) > len(dirs[j]) })
 	for _, dir := range dirs {
+		entries, readErr := os.ReadDir(dir)
+		if readErr != nil {
+			continue
+		}
+		if len(entries) > 0 {
+			continue
+		}
 		if err := os.Remove(dir); err != nil && !errors.Is(err, os.ErrNotExist) {
 			if errors.Is(err, syscall.ENOTEMPTY) || errors.Is(err, syscall.EEXIST) {
 				continue

--- a/internal/book/versions/service_test.go
+++ b/internal/book/versions/service_test.go
@@ -204,6 +204,54 @@ func TestGoGitVersionExcludesRunLedgers(t *testing.T) {
 	}
 }
 
+func TestGoGitVersionExcludesInteractiveData(t *testing.T) {
+	dir := t.TempDir()
+	service := NewService(dir)
+	settings := DefaultAutoSettings()
+	writeFile(t, dir, "chapters/ch0001.md", "第一版")
+	writeFile(t, dir, ".nova/interactive/stories/story-1.json", `{"title":"测试故事"}`)
+	writeFile(t, dir, ".nova/interactive/memory/book.json", `{"structures":[]}`)
+
+	first, err := service.Create("初始版本", VersionSourceManual, settings)
+	if err != nil {
+		t.Fatalf("Create first failed: %v", err)
+	}
+	files, err := service.commitFiles(first.Version.ID)
+	if err != nil {
+		t.Fatalf("commitFiles first failed: %v", err)
+	}
+	if _, ok := files[".nova/interactive/stories/story-1.json"]; ok {
+		t.Fatalf("interactive data should not be committed: %v", sortedVersionFilePaths(files))
+	}
+	if _, err := os.Stat(filepath.Join(dir, ".nova", "interactive", "stories", "story-1.json")); err != nil {
+		t.Fatalf("interactive data should remain in workspace: %v", err)
+	}
+
+	writeFile(t, dir, "chapters/ch0001.md", "第二版")
+	if _, err := service.Create("第二版本", VersionSourceManual, settings); err != nil {
+		t.Fatalf("Create second failed: %v", err)
+	}
+
+	if _, err := service.Restore(first.Version.ID, settings); err != nil {
+		t.Fatalf("Restore failed: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, ".nova", "interactive", "stories", "story-1.json")); err != nil {
+		t.Fatalf("interactive data should survive version restore: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, ".nova", "interactive", "memory", "book.json")); err != nil {
+		t.Fatalf("interactive memory should survive version restore: %v", err)
+	}
+
+	writeFile(t, dir, ".nova/interactive/stories/story-2.json", `{"title":"新故事"}`)
+	status, err := service.Status(settings)
+	if err != nil {
+		t.Fatalf("Status failed: %v", err)
+	}
+	if !status.Clean {
+		t.Fatalf("interactive data changes should not dirty version status: %#v", status.Changes)
+	}
+}
+
 func writeFile(t *testing.T, root, rel, content string) {
 	t.Helper()
 	path := filepath.Join(root, filepath.FromSlash(rel))

--- a/internal/prompts/interactive.go
+++ b/internal/prompts/interactive.go
@@ -212,6 +212,7 @@ func BuildInteractiveStateSystemInstruction() string {
 		"必须基于注入的“故事记忆结构与字段协议”输出 patch；structure_id、key_field_id、values 字段名和值的写法要求都只能来自该协议。",
 		"每次写入某张表时，values 必须按该表的字段列表逐字段填写：优先满足 required 字段，同时尽量补齐全部字段；字段值必须遵守表级 generation_instruction 和字段级 generation_instruction。",
 		"不能只填 required 字段或本回合变化字段；有既有记录时必须沿用并整合未变化字段，不得省略字段、写空字符串或 null。",
+		"必须逐个检查全部已启用结构，判断本回合是否有需要更新的记录，不得遗漏任何结构。",
 		"字段值必须综合三类来源：历史回合上下文、资料库相关人物与设定、本回合前的既有故事记忆；新剧情负责更新变化，资料库负责校准设定，既有记忆负责保留未变化字段。",
 		"op 仅使用 upsert、append、archive、restore；singleton 用 upsert，keyed 用带 key 的 upsert，append 结构记录新发生且后续需要承接的事实；结束或不再参与后续判断的记录用 archive。",
 		"keyed 结构必须输出非空 key，且 values 必须包含 key_field_id 对应字段；key 必须等于该字段值。",
@@ -238,7 +239,7 @@ func InteractiveStateInstruction(in InteractiveStatePromptInput) string {
 	writeBlock(&sb, "历史回合上下文", in.TurnHistory)
 	writeBlock(&sb, "用户本回合行动", in.UserAction)
 	writeBlock(&sb, "已生成的本回合正文", in.Narrative)
-	sb.WriteString("\n只输出 JSON，例如：{\"story_memory_patches\":[{\"op\":\"upsert\",\"structure_id\":\"current_state\",\"values\":{\"location\":\"旧宅门厅\",\"time\":\"2026-06-19 22:10\",\"previous_time\":\"2026-06-19 22:00\",\"elapsed_time\":\"约十分钟\",\"event\":\"主角发现门厅的铜铃会回应钥匙。\"}},{\"op\":\"upsert\",\"structure_id\":\"important_character\",\"key\":\"林川\",\"values\":{\"name\":\"林川\",\"brief\":\"熟悉旧宅机关的同行者\",\"relationship\":\"提醒主角谨慎使用铜钥匙\",\"status\":\"与主角同在旧宅门厅\"}},{\"op\":\"append\",\"structure_id\":\"plot_summary\",\"values\":{\"time\":\"2026-06-19 22:10\",\"place\":\"旧宅门厅\",\"event\":\"主角用铜钥匙触发门厅铜铃，确认旧宅对钥匙有反应。\"}}]}。\n")
+	sb.WriteString("\n只输出 JSON，例如：{\"story_memory_patches\":[{\"op\":\"upsert\",\"structure_id\":\"current_state\",\"values\":{\"location\":\"旧宅门厅\",\"time\":\"2026-06-19 22:10\",\"previous_time\":\"2026-06-19 22:00\",\"elapsed_time\":\"约十分钟\",\"event\":\"主角发现门厅的铜铃会回应钥匙。\"}},{\"op\":\"upsert\",\"structure_id\":\"protagonist\",\"values\":{\"name\":\"主角\",\"current_goal\":\"探索旧宅机关\",\"emotional_state\":\"警觉\",\"inventory\":\"铜钥匙、手电筒\",\"health\":\"良好\"}},{\"op\":\"upsert\",\"structure_id\":\"important_character\",\"key\":\"林川\",\"values\":{\"name\":\"林川\",\"brief\":\"熟悉旧宅机关的同行者\",\"relationship\":\"提醒主角谨慎使用铜钥匙\",\"status\":\"与主角同在旧宅门厅\"}},{\"op\":\"upsert\",\"structure_id\":\"world_context\",\"values\":{\"time_period\":\"现代\",\"weather\":\"夜雨\",\"atmosphere\":\"神秘紧张\"}},{\"op\":\"upsert\",\"structure_id\":\"open_threads\",\"key\":\"铜铃机关\",\"values\":{\"thread\":\"铜铃对钥匙的反应暗示旧宅有隐藏机关\",\"status\":\"待调查\",\"priority\":\"高\"}},{\"op\":\"append\",\"structure_id\":\"plot_summary\",\"values\":{\"time\":\"2026-06-19 22:10\",\"place\":\"旧宅门厅\",\"event\":\"主角用铜钥匙触发门厅铜铃，确认旧宅对钥匙有反应。\"}}]}。\n")
 	return sb.String()
 }
 

--- a/web/src/hooks/useAgentEventStream.ts
+++ b/web/src/hooks/useAgentEventStream.ts
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState, type Dispatch, type SetStateAction } from 'react'
+import { useCallback, useEffect, useRef, useState, type Dispatch, type SetStateAction } from 'react'
 import { useTranslation } from 'react-i18next'
 import type { ChatMessage, SSEEvent } from '@/lib/api'
 import { buildContextCompactionMessage, createContextCompactionMessageId, upsertContextCompactionMessage } from '@/components/Chat/context-compaction-message'
@@ -337,6 +337,13 @@ export function useAgentEventStream(options: AgentEventStreamOptions = {}) {
     onEvent,
     t,
   ])
+
+  useEffect(() => {
+    return () => {
+      abortControllerRef.current?.abort()
+      abortControllerRef.current = null
+    }
+  }, [])
 
   return {
     messages,


### PR DESCRIPTION
## 概述

本 PR 修复了 4 个 bug，基于 upstream/master rebase，不包含任何新功能。

### 1. 互动记忆 Agent 超时与重试失效
- **问题**：总超时仅 2 分钟，且 3 次重试共用同一个 context。第一次超时后 context 已取消，后续重试立即返回。
- **修复**：
  - 总超时从 2 分钟增加到 5 分钟 (`interactive_state.go`)
  - 每次重试独立 2 分钟子 context (`interactive_memory_retry.go`)

### 2. 离开界面后记忆整理进程丢失
- **问题**：用户从剧情界面切到其他界面时，组件卸载但 SSE 流未被 abort，结果丢失。
- **修复**：添加 `useEffect` cleanup，组件卸载时自动 abort 流 (`useAgentEventStream.ts`)

### 3. 记忆整理只更新 3 个结构
- **问题**：Schema 上下文限制仅 8KB，6 个默认结构超过此限制，AI 只看到前 3 个。
- **修复**：
  - Schema 限制从 8KB 增大到 24KB (`interactive_conversation.go`)
  - 提示词新增"必须逐个检查全部已启用结构"指令，示例覆盖全部 6 个默认结构 (`interactive.go`)

### 4. 版本回溯丢失互动故事数据
- **问题**：
  - `.nova/interactive` 未被排除，版本回溯到旧版本时会删除互动故事数据。
  - `removeEmptyVisibleDirs` 因 `SkipDir` 误判父目录为空，删除了整个 `.nova` 目录。
- **修复**：
  - 将 `.nova/interactive` 加入版本排除列表 (`files.go`)
  - `removeEmptyVisibleDirs` 改用 `os.ReadDir` 检查目录是否真的为空 (`restore.go`)
  - 新增测试验证互动数据在版本回溯后存活 (`service_test.go`)

## 测试
- 所有现有测试通过
- 新测试 `TestGoGitVersionExcludesInteractiveData` 验证互动数据在版本回溯后存活