### PR TITLE
修复 MiniMax 等模型输出渲染与工具调用 close #19

### DIFF
--- a/config/settings.go
+++ b/config/settings.go
@@ -13,6 +13,7 @@ import (
 // Settings 是用户可见且可在三层配置中持久化的字段。
 // 指针类型用于区分 "未设置"（继承上层）与 "显式置零"。
 type Settings struct {
+
 	// 模型
 	OpenAIAPIKey              string                 `toml:"openai_api_key,omitempty" json:"openai_api_key,omitempty"`
 	OpenAIBaseURL             string                 `toml:"openai_base_url,omitempty" json:"openai_base_url,omitempty"`

--- a/internal/agent/builder.go
+++ b/internal/agent/builder.go
@@ -19,6 +19,7 @@ import (
 	"nova/config"
 	"nova/internal/book"
 	"nova/internal/prompts"
+	"nova/internal/providercompat"
 	novaskills "nova/internal/skills"
 )
 
@@ -67,8 +68,7 @@ func BuildInteractiveStory(ctx context.Context, cfg *config.Config, state *book.
 		Instruction:       BuildInteractiveStoryInstruction(cfg, state, teller),
 		EnableSkills:      true,
 		DisableWriteTodos: true,
-		ExtraTools:        extraTools,
-	})
+		ExtraTools:        extraTools,	})
 }
 
 // BuildConfigManagerAgent 构建统一配置管理 Agent（deep agent + 通用工具 + Skill + 模块资源工具）。
@@ -137,6 +137,9 @@ func buildDeepAgent(ctx context.Context, cfg *config.Config, spec deepAgentSpec)
 	if err != nil {
 		return nil, fmt.Errorf("创建模型失败: %w", err)
 	}
+	// providercompat 决定是否要为这个 provider 加包装层（修复工具调用格式、剥离内联 think 等）。
+	// agent 包不感知具体 provider；新增 provider 的兼容性处理只需在 providercompat 里加。
+	chatModel := providercompat.Wrap(cm, modelCfg)
 
 	localBackend, err := localbk.NewBackend(ctx, &localbk.Config{})
 	if err != nil {
@@ -193,7 +196,7 @@ func buildDeepAgent(ctx context.Context, cfg *config.Config, spec deepAgentSpec)
 	return deep.New(ctx, &deep.Config{
 		Name:              spec.Name,
 		Description:       spec.Description,
-		ChatModel:         cm,
+		ChatModel:         chatModel,
 		Instruction:       spec.Instruction,
 		WithoutWriteTodos: spec.DisableWriteTodos || !toolSettings.Todo,
 		MaxIteration:      configMaxIteration(cfg),

--- a/internal/agent/model.go
+++ b/internal/agent/model.go
@@ -4,6 +4,7 @@ import (
 	"github.com/cloudwego/eino-ext/components/model/openai"
 
 	"nova/config"
+	"nova/internal/providercompat"
 )
 
 func chatModelConfigForAgent(cfg *config.Config, agentKind string) openai.ChatModelConfig {
@@ -17,10 +18,17 @@ func chatModelConfigForAgent(cfg *config.Config, agentKind string) openai.ChatMo
 		temperature := float32(*resolved.Temperature)
 		modelCfg.Temperature = &temperature
 	}
+	extraFields := map[string]any{}
 	if resolved.EnableThinking != nil {
-		modelCfg.ExtraFields = map[string]any{
-			"enable_thinking": *resolved.EnableThinking,
-		}
+		extraFields["enable_thinking"] = *resolved.EnableThinking
+	}
+	// 让 providercompat 决定是否要注入 provider 特有的请求字段。
+	// agent 包不感知任何具体 provider。
+	for k, v := range providercompat.ExtraRequestFields(modelCfg) {
+		extraFields[k] = v
+	}
+	if len(extraFields) > 0 {
+		modelCfg.ExtraFields = extraFields
 	}
 	if resolved.ReasoningEffort != "" {
 		modelCfg.ReasoningEffort = openai.ReasoningEffortLevel(resolved.ReasoningEffort)

--- a/internal/app/interactive_agent_test.go
+++ b/internal/app/interactive_agent_test.go
@@ -617,6 +617,18 @@ func TestParseInteractiveAssistantOutput(t *testing.T) {
 		t.Fatalf("expected invalid state to fall back to async state, narrative=%q ops=%#v err=%v", narrative, ops, err)
 	}
 
+	// 思考前言无 <think> 开始标签、仅以 </think> 收尾，随后才是 <NARRATIVE>。
+	narrative, _, _, err = parseInteractiveAssistantOutput("tags\n\nLet me write the opening:</think>\n\n<NARRATIVE>\n意识像被冷水浇醒。\n</NARRATIVE>")
+	if err != nil || narrative != "意识像被冷水浇醒。" {
+		t.Fatalf("expected orphan </think> prelude stripped before <NARRATIVE>, narrative=%q err=%v", narrative, err)
+	}
+
+	// 思考前言 + 裸正文（未输出 <NARRATIVE>）。
+	narrative, _, _, err = parseInteractiveAssistantOutput("思考中...</think>\n真正的正文。")
+	if err != nil || narrative != "真正的正文。" {
+		t.Fatalf("expected orphan </think> without narrative stripped, narrative=%q err=%v", narrative, err)
+	}
+
 	_, _, _, err = parseInteractiveAssistantOutput("<STATE_DELTA>{\"ops\":[]}</STATE_DELTA>")
 	if err == nil {
 		t.Fatalf("expected empty narrative error")

--- a/internal/app/interactive_response.go
+++ b/internal/app/interactive_response.go
@@ -15,6 +15,8 @@ const (
 	narrativeEndTag    = "</NARRATIVE>"
 	stateDeltaStartTag = "<STATE_DELTA>"
 	stateDeltaEndTag   = "</STATE_DELTA>"
+	thinkOpenTag       = "<think>"
+	thinkCloseTag      = "</think>"
 )
 
 type interactiveStatePayload struct {
@@ -147,12 +149,37 @@ func parseInteractiveHotState(content string) (*interactive.HotState, error) {
 
 func extractNarrative(content string) string {
 	if narrative, ok := extractBetween(content, narrativeStartTag, narrativeEndTag); ok {
-		return narrative
+		return stripThinkPrelude(narrative)
 	}
 	if idx := firstHiddenStateTagIndex(content); idx >= 0 {
-		return content[:idx]
+		return stripThinkPrelude(content[:idx])
 	}
-	return content
+	return stripThinkPrelude(content)
+}
+
+// stripThinkPrelude 移除叙事正文里残留的思考块，兜底模型把思考混入正文的情况：
+// 配对 <think>...</think>、未闭合 <think>...，以及无开始标签、仅以 </think> 收尾的前言。
+func stripThinkPrelude(s string) string {
+	for {
+		open := thinkIndexFold(s, thinkOpenTag)
+		if open < 0 {
+			break
+		}
+		closeIdx := thinkIndexFold(s[open:], thinkCloseTag)
+		if closeIdx < 0 {
+			s = s[:open]
+			break
+		}
+		s = s[:open] + s[open+closeIdx+len(thinkCloseTag):]
+	}
+	if closeIdx := thinkIndexFold(s, thinkCloseTag); closeIdx >= 0 {
+		s = s[closeIdx+len(thinkCloseTag):]
+	}
+	return strings.TrimSpace(s)
+}
+
+func thinkIndexFold(s, sub string) int {
+	return strings.Index(strings.ToLower(s), strings.ToLower(sub))
 }
 
 func firstHiddenStateTagIndex(content string) int {

--- a/internal/providercompat/polyfill.go
+++ b/internal/providercompat/polyfill.go
@@ -1,0 +1,315 @@
+// Package providercompat provides model-output compatibility polyfills.
+//
+// Some OpenAI-compatible providers (e.g. MiniMax) don't return standard
+// tool_calls or wrap thinking in <think> tags inside content. This package
+// offers a single entry point — Wrap — that inspects the model config and
+// transparently adapts the chat model when the provider needs it. Main code
+// (e.g. internal/agent) should not branch on provider names; instead it
+// just calls Wrap(cm, cfg) and forgets about it.
+package providercompat
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"regexp"
+	"strings"
+
+	"github.com/cloudwego/eino-ext/components/model/openai"
+	"github.com/cloudwego/eino/components/model"
+	"github.com/cloudwego/eino/schema"
+)
+
+// Wrap returns a possibly-decorated chat model that hides provider-specific
+// quirks. If the model needs no polyfill, the original is returned untouched.
+func Wrap(cm model.ToolCallingChatModel, cfg openai.ChatModelConfig) model.ToolCallingChatModel {
+	if polyfills := detect(cfg); len(polyfills) > 0 {
+		log.Printf("[providercompat] applying %d polyfill(s) model=%q", len(polyfills), cfg.Model)
+		cm = chain(cm, polyfills)
+	}
+	return cm
+}
+
+// ExtraRequestFields returns provider-specific fields that should be merged
+// into the request body (e.g. reasoning_split for MiniMax). Called once when
+// building the chat model config, before any request is sent.
+func ExtraRequestFields(cfg openai.ChatModelConfig) map[string]any {
+	out := map[string]any{}
+	if isMinimax(cfg) {
+		// MiniMax-M3 默认把思考写入 content 的 <think> 标签；reasoning_split=true 让其改用
+		// 标准 reasoning_content 字段返回，从根本上避免 <think> 泄漏到正文
+		// （见 MiniMax OpenAI 兼容文档）。
+		out["reasoning_split"] = true
+	}
+	return out
+}
+
+type polyfill interface {
+	apply(model.ToolCallingChatModel) model.ToolCallingChatModel
+}
+
+// detect inspects the config and returns the polyfill chain to apply.
+// Order matters: later polyfills see output of earlier ones.
+func detect(cfg openai.ChatModelConfig) []polyfill {
+	var out []polyfill
+	if isMinimax(cfg) {
+		// Both polyfills needed: tool-call text-to-struct, then think-tag cleanup
+		// (in case reasoning_split is ignored or falls back to inline tags).
+		out = append(out, toolCallTextPolyfill{})
+		out = append(out, inlineThinkPolyfill{})
+	}
+	return out
+}
+
+func chain(cm model.ToolCallingChatModel, ps []polyfill) model.ToolCallingChatModel {
+	for _, p := range ps {
+		cm = p.apply(cm)
+	}
+	return cm
+}
+
+// isMinimax checks the base URL or model name. Cheap, called once per Wrap.
+func isMinimax(cfg openai.ChatModelConfig) bool {
+	base := strings.ToLower(cfg.BaseURL)
+	return strings.Contains(base, "minimax") || strings.Contains(strings.ToLower(cfg.Model), "minimax")
+}
+
+// -----------------------------------------------------------------------------
+// Polyfill 1: tool calls delivered as inline text instead of structured
+// tool_calls. We parse the antml-style <tool_call><invoke name="...">…</invoke> </tool_call>
+// XML and promote them to schema.ToolCall so the framework actually executes
+// the tools.
+// -----------------------------------------------------------------------------
+
+type toolCallTextPolyfill struct{}
+
+var (
+	pcInvokeRe    = regexp.MustCompile(`(?s)<invoke\s+name="([^"]+)"\s*>(.*?)</invoke>`)
+	pcToolCallRe  = regexp.MustCompile(`(?s)<tool_call>(.*?)</tool_call>`)
+	pcParamNamedR = regexp.MustCompile(`(?s)<parameter\s+name="([^"]+)"\s*>(.*?)</parameter>`)
+	pcParamTagR   = regexp.MustCompile(`(?s)<([a-zA-Z_][\w.-]*)>(.*?)</[a-zA-Z_][\w.-]*>`)
+)
+
+func (toolCallTextPolyfill) apply(inner model.ToolCallingChatModel) model.ToolCallingChatModel {
+	return &toolCallTextModel{inner: inner}
+}
+
+type toolCallTextModel struct{ inner model.ToolCallingChatModel }
+
+func (m *toolCallTextModel) Generate(ctx context.Context, in []*schema.Message, opts ...model.Option) (*schema.Message, error) {
+	msg, err := m.inner.Generate(ctx, in, opts...)
+	if err != nil || msg == nil {
+		return msg, err
+	}
+	extractTextToolCalls(msg)
+	return msg, nil
+}
+
+func (m *toolCallTextModel) Stream(ctx context.Context, in []*schema.Message, opts ...model.Option) (*schema.StreamReader[*schema.Message], error) {
+	// Tool-call extraction requires full content (it must see the closing </tool_call>
+	// to know the call is complete). Buffer the whole stream, then re-emit as
+	// a single frame so downstream logic receives a repaired message.
+	sr, err := m.inner.Stream(ctx, in, opts...)
+	if err != nil {
+		return nil, err
+	}
+	defer sr.Close()
+	var frames []*schema.Message
+	for {
+		f, err := sr.Recv()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		if f != nil {
+			frames = append(frames, f)
+		}
+	}
+	if len(frames) == 0 {
+		return schema.StreamReaderFromArray(frames), nil
+	}
+	merged, err := schema.ConcatMessages(frames)
+	if err != nil || merged == nil {
+		return schema.StreamReaderFromArray(frames), nil
+	}
+	extractTextToolCalls(merged)
+	return schema.StreamReaderFromArray([]*schema.Message{merged}), nil
+}
+
+func (m *toolCallTextModel) WithTools(tools []*schema.ToolInfo) (model.ToolCallingChatModel, error) {
+	inner, err := m.inner.WithTools(tools)
+	if err != nil {
+		return nil, err
+	}
+	return &toolCallTextModel{inner: inner}, nil
+}
+
+func extractTextToolCalls(msg *schema.Message) {
+	if msg == nil || len(msg.ToolCalls) > 0 || msg.Content == "" {
+		return
+	}
+	matches := pcInvokeRe.FindAllStringSubmatch(msg.Content, -1)
+	if len(matches) == 0 {
+		return
+	}
+	calls := make([]schema.ToolCall, 0, len(matches))
+	for i, m := range matches {
+		name := strings.TrimSpace(m[1])
+		if name == "" {
+			continue
+		}
+		params := parseInvokeParams(m[2])
+		args, _ := json.Marshal(params)
+		idx := i
+		calls = append(calls, schema.ToolCall{
+			Index: &idx,
+			ID:    fmt.Sprintf("text_tool_call_%d", i),
+			Type:  "function",
+			Function: schema.FunctionCall{
+				Name:      name,
+				Arguments: string(args),
+			},
+		})
+	}
+	if len(calls) == 0 {
+		return
+	}
+	msg.ToolCalls = calls
+	msg.Content = pcToolCallRe.ReplaceAllString(msg.Content, "")
+	msg.Content = pcInvokeRe.ReplaceAllString(msg.Content, "")
+}
+
+func parseInvokeParams(body string) map[string]string {
+	out := map[string]string{}
+	if named := pcParamNamedR.FindAllStringSubmatch(body, -1); len(named) > 0 {
+		for _, m := range named {
+			if k := strings.TrimSpace(m[1]); k != "" {
+				out[k] = strings.TrimSpace(m[2])
+			}
+		}
+		return out
+	}
+	for _, m := range pcParamTagR.FindAllStringSubmatch(body, -1) {
+		k := strings.TrimSpace(m[1])
+		if k == "" || strings.EqualFold(k, "parameter") {
+			continue
+		}
+		out[k] = strings.TrimSpace(m[2])
+	}
+	return out
+}
+
+// -----------------------------------------------------------------------------
+// Polyfill 2: some providers (or fallback paths) still emit <think>…</think>
+// inline. Strip them from content and surface as ReasoningContent if missing.
+// -----------------------------------------------------------------------------
+
+type inlineThinkPolyfill struct{}
+
+func (inlineThinkPolyfill) apply(inner model.ToolCallingChatModel) model.ToolCallingChatModel {
+	return &inlineThinkModel{inner: inner}
+}
+
+type inlineThinkModel struct{ inner model.ToolCallingChatModel }
+
+func (m *inlineThinkModel) Generate(ctx context.Context, in []*schema.Message, opts ...model.Option) (*schema.Message, error) {
+	msg, err := m.inner.Generate(ctx, in, opts...)
+	if err != nil || msg == nil {
+		return msg, err
+	}
+	stripInlineThink(msg)
+	return msg, nil
+}
+
+func (m *inlineThinkModel) Stream(ctx context.Context, in []*schema.Message, opts ...model.Option) (*schema.StreamReader[*schema.Message], error) {
+	sr, err := m.inner.Stream(ctx, in, opts...)
+	if err != nil {
+		return nil, err
+	}
+	defer sr.Close()
+	var frames []*schema.Message
+	for {
+		f, err := sr.Recv()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		if f != nil {
+			frames = append(frames, f)
+		}
+	}
+	if len(frames) == 0 {
+		return schema.StreamReaderFromArray(frames), nil
+	}
+	merged, err := schema.ConcatMessages(frames)
+	if err != nil || merged == nil {
+		return schema.StreamReaderFromArray(frames), nil
+	}
+	stripInlineThink(merged)
+	return schema.StreamReaderFromArray([]*schema.Message{merged}), nil
+}
+
+func (m *inlineThinkModel) WithTools(tools []*schema.ToolInfo) (model.ToolCallingChatModel, error) {
+	inner, err := m.inner.WithTools(tools)
+	if err != nil {
+		return nil, err
+	}
+	return &inlineThinkModel{inner: inner}, nil
+}
+
+func stripInlineThink(msg *schema.Message) {
+	if msg == nil || msg.Content == "" {
+		return
+	}
+	clean, thinking := stripThinkTagsSimple(msg.Content)
+	if thinking != "" && strings.TrimSpace(msg.ReasoningContent) == "" {
+		msg.ReasoningContent = thinking
+	}
+	msg.Content = clean
+}
+
+// stripThinkTagsSimple removes paired/unclosed <think>…</think> and orphan </think>
+// prelude in one shot. Used on whole-message content (post-stream concat), so
+// regex is fine — no cross-chunk state to maintain. The agent package's
+// thinkTagExtractor handles the streaming variant separately.
+func stripThinkTagsSimple(s string) (content, thinking string) {
+	// paired <think>…</think> (lazy, may not find anything if unclosed)
+	paired := regexp.MustCompile(`(?is)<think>(.*?)(?:</think>|$)`)
+	matches := paired.FindAllStringSubmatchIndex(s, -1)
+	if len(matches) == 0 {
+		// no <think> opener: maybe an orphan </think> prelude
+		if idx := strings.Index(strings.ToLower(s), "</think>"); idx >= 0 {
+			prelude := strings.TrimSpace(s[:idx])
+			if prelude != "" {
+				thinking = prelude
+			}
+			content = strings.TrimLeft(s[idx+len("</think>"):], " \t\r\n")
+		} else {
+			content = s
+		}
+		return content, thinking
+	}
+	var contentBuilder, thinkBuilder strings.Builder
+	last := 0
+	for _, m := range matches {
+		if m[0] > last {
+			contentBuilder.WriteString(s[last:m[0]])
+		}
+		thinkBuilder.WriteString(s[m[2]:m[3]])
+		last = m[1]
+	}
+	contentBuilder.WriteString(s[last:])
+	// also strip any orphan </think> remaining in the content tail
+	content = paired.ReplaceAllString(contentBuilder.String(), "")
+	// and any orphan </think> fragments
+	content = regexp.MustCompile(`(?i)\n?</think>\s*`).ReplaceAllString(content, "")
+	content = strings.TrimLeft(content, " \t\r\n")
+	return content, thinkBuilder.String()
+}

--- a/internal/providercompat/polyfill.go
+++ b/internal/providercompat/polyfill.go
@@ -1,9 +1,9 @@
 // Package providercompat provides model-output compatibility polyfills.
 //
-// Some OpenAI-compatible providers (e.g. MiniMax) don't return standard
-// tool_calls or wrap thinking in <think> tags inside content. This package
-// offers a single entry point — Wrap — that inspects the model config and
-// transparently adapts the chat model when the provider needs it. Main code
+// Some OpenAI-compatible providers don't return standard tool_calls or wrap
+// thinking in <think> tags inside content. This package offers a single
+// entry point — Wrap — that inspects the model config and transparently
+// adapts the chat model when the provider needs it. Main code
 // (e.g. internal/agent) should not branch on provider names; instead it
 // just calls Wrap(cm, cfg) and forgets about it.
 package providercompat
@@ -34,14 +34,14 @@ func Wrap(cm model.ToolCallingChatModel, cfg openai.ChatModelConfig) model.ToolC
 }
 
 // ExtraRequestFields returns provider-specific fields that should be merged
-// into the request body (e.g. reasoning_split for MiniMax). Called once when
+// into the request body (e.g. reasoning_split to ask the API to return
+// thinking via the standard reasoning_content field). Called once when
 // building the chat model config, before any request is sent.
 func ExtraRequestFields(cfg openai.ChatModelConfig) map[string]any {
 	out := map[string]any{}
-	if isMinimax(cfg) {
-		// MiniMax-M3 默认把思考写入 content 的 <think> 标签；reasoning_split=true 让其改用
-		// 标准 reasoning_content 字段返回，从根本上避免 <think> 泄漏到正文
-		// （见 MiniMax OpenAI 兼容文档）。
+	if needsRepair(cfg) {
+		// Ask the provider to return thinking via the standard
+		// reasoning_content field, instead of embedding it in content.
 		out["reasoning_split"] = true
 	}
 	return out
@@ -55,7 +55,7 @@ type polyfill interface {
 // Order matters: later polyfills see output of earlier ones.
 func detect(cfg openai.ChatModelConfig) []polyfill {
 	var out []polyfill
-	if isMinimax(cfg) {
+	if needsRepair(cfg) {
 		// Both polyfills needed: tool-call text-to-struct, then think-tag cleanup
 		// (in case reasoning_split is ignored or falls back to inline tags).
 		out = append(out, toolCallTextPolyfill{})
@@ -71,10 +71,22 @@ func chain(cm model.ToolCallingChatModel, ps []polyfill) model.ToolCallingChatMo
 	return cm
 }
 
-// isMinimax checks the base URL or model name. Cheap, called once per Wrap.
-func isMinimax(cfg openai.ChatModelConfig) bool {
+// needsRepair returns true when the provider's OpenAI-compatible endpoint
+// does not return standard tool_calls or wraps thinking in <think> tags.
+// Detection is by base URL or model name matching a known non-standard
+// marker. "minimax" is a known host keyword of an OpenAI-compatible
+// provider that exhibits these quirks; "non-standard" and
+// "incompatible" are generic markers users can opt into via their
+// base URL or model name. Cheap, called once per Wrap.
+func needsRepair(cfg openai.ChatModelConfig) bool {
 	base := strings.ToLower(cfg.BaseURL)
-	return strings.Contains(base, "minimax") || strings.Contains(strings.ToLower(cfg.Model), "minimax")
+	model := strings.ToLower(cfg.Model)
+	for _, marker := range []string{"minimax", "non-standard", "incompatible"} {
+		if strings.Contains(base, marker) || strings.Contains(model, marker) {
+			return true
+		}
+	}
+	return false
 }
 
 // -----------------------------------------------------------------------------

--- a/internal/providercompat/polyfill.go
+++ b/internal/providercompat/polyfill.go
@@ -27,7 +27,7 @@ import (
 // quirks. If the model needs no polyfill, the original is returned untouched.
 func Wrap(cm model.ToolCallingChatModel, cfg openai.ChatModelConfig) model.ToolCallingChatModel {
 	if polyfills := detect(cfg); len(polyfills) > 0 {
-		log.Printf("[providercompat] applying %d polyfill(s) model=%q", len(polyfills), cfg.Model)
+		log.Printf("[providercompat] Wrap called: applying %d polyfill(s) model=%q" , len(polyfills), cfg.Model)
 		cm = chain(cm, polyfills)
 	}
 	return cm

--- a/internal/providercompat/polyfill_test.go
+++ b/internal/providercompat/polyfill_test.go
@@ -1,0 +1,116 @@
+package providercompat
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/cloudwego/eino-ext/components/model/openai"
+	"github.com/cloudwego/eino/components/model"
+	"github.com/cloudwego/eino/schema"
+)
+
+// fakeChatModel is a minimal ToolCallingChatModel that returns a fixed
+// message. We use it to assert that Wrap repairs the inner model's output.
+type fakeChatModel struct {
+	fixedMsg *schema.Message
+}
+
+func (f *fakeChatModel) Generate(_ context.Context, _ []*schema.Message, _ ...model.Option) (*schema.Message, error) {
+	return f.fixedMsg, nil
+}
+func (f *fakeChatModel) Stream(_ context.Context, _ []*schema.Message, _ ...model.Option) (*schema.StreamReader[*schema.Message], error) {
+	if f.fixedMsg == nil {
+		return schema.StreamReaderFromArray([]*schema.Message{}), nil
+	}
+	return schema.StreamReaderFromArray([]*schema.Message{f.fixedMsg}), nil
+}
+func (f *fakeChatModel) WithTools(_ []*schema.ToolInfo) (model.ToolCallingChatModel, error) {
+	return f, nil
+}
+
+func TestExtraRequestFields_MiniMax(t *testing.T) {
+	cfg := openai.ChatModelConfig{BaseURL: "https://minimaxi.com/v1/", Model: "MiniMax-M3"}
+	got := ExtraRequestFields(cfg)
+	if v, ok := got["reasoning_split"]; !ok || v != true {
+		t.Fatalf("expected reasoning_split=true for MiniMax, got %v", got)
+	}
+}
+
+func TestExtraRequestFields_OtherProvider(t *testing.T) {
+	for _, cfg := range []openai.ChatModelConfig{
+		{BaseURL: "https://api.openai.com/v1", Model: "gpt-4o"},
+		{BaseURL: "https://api.deepseek.com/v1", Model: "deepseek-chat"},
+	} {
+		if got := ExtraRequestFields(cfg); len(got) != 0 {
+			t.Fatalf("expected no extras for %s, got %v", cfg.BaseURL, got)
+		}
+	}
+}
+
+func TestWrap_MiniMax_RepairsToolCallAndThink(t *testing.T) {
+	// 复刻真实 MiniMax-M3 输出：think + 文本工具调用 + 内部特殊 token
+	content := "<think>Let me load the skill.</think>\n\n" +
+		"加载 rewrite skill 的具体流程。<tool_call>\n" +
+		"<invoke name=\"skill\"><skill>rewrite</skill></invoke>\n" +
+		"</tool_call>"
+	inner := &fakeChatModel{fixedMsg: &schema.Message{Role: schema.Assistant, Content: content}}
+	cfg := openai.ChatModelConfig{BaseURL: "https://minimaxi.com/v1/", Model: "MiniMax-M3"}
+
+	wrapped := Wrap(inner, cfg)
+	out, err := wrapped.Generate(context.Background(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(out.ToolCalls) != 1 {
+		t.Fatalf("expected 1 tool call, got %d (%#v)", len(out.ToolCalls), out.ToolCalls)
+	}
+	if name := out.ToolCalls[0].Function.Name; name != "skill" {
+		t.Fatalf("tool name = %q, want skill", name)
+	}
+	if args := out.ToolCalls[0].Function.Arguments; args != `{"skill":"rewrite"}` {
+		t.Fatalf("args = %q, want {\"skill\":\"rewrite\"}", args)
+	}
+	if out.Content != "加载 rewrite skill 的具体流程。" {
+		t.Fatalf("content = %q", out.Content)
+	}
+	if !strings.Contains(out.ReasoningContent, "load the skill") {
+		t.Fatalf("reasoning not captured: %q", out.ReasoningContent)
+	}
+}
+
+func TestWrap_MiniMax_PreservesNativeToolCalls(t *testing.T) {
+	idx := 0
+	inner := &fakeChatModel{fixedMsg: &schema.Message{
+		Role:    schema.Assistant,
+		Content: "正文",
+		ToolCalls: []schema.ToolCall{{
+			Index: &idx, ID: "x", Type: "function",
+			Function: schema.FunctionCall{Name: "read_file", Arguments: "{}"},
+		}},
+	}}
+	cfg := openai.ChatModelConfig{BaseURL: "https://minimaxi.com/v1/", Model: "MiniMax-M3"}
+	out, err := Wrap(inner, cfg).Generate(context.Background(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(out.ToolCalls) != 1 || out.ToolCalls[0].Function.Name != "read_file" {
+		t.Fatalf("native tool calls altered: %#v", out.ToolCalls)
+	}
+}
+
+func TestWrap_OtherProvider_PassThrough(t *testing.T) {
+	inner := &fakeChatModel{fixedMsg: &schema.Message{Role: schema.Assistant, Content: "raw <think>oops</think> done"}}
+	cfg := openai.ChatModelConfig{BaseURL: "https://api.openai.com/v1", Model: "gpt-4o"}
+	// OpenAI 端点：原样返回，think 标签不应被剥离（信任它走 reasoning_content 字段）
+	out, err := Wrap(inner, cfg).Generate(context.Background(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.Content != "raw <think>oops</think> done" {
+		t.Fatalf("OpenAI output unexpectedly modified: %q", out.Content)
+	}
+	if out.ReasoningContent != "" {
+		t.Fatalf("OpenAI reasoning unexpectedly populated: %q", out.ReasoningContent)
+	}
+}

--- a/internal/providercompat/polyfill_test.go
+++ b/internal/providercompat/polyfill_test.go
@@ -29,15 +29,22 @@ func (f *fakeChatModel) WithTools(_ []*schema.ToolInfo) (model.ToolCallingChatMo
 	return f, nil
 }
 
-func TestExtraRequestFields_MiniMax(t *testing.T) {
-	cfg := openai.ChatModelConfig{BaseURL: "https://minimaxi.com/v1/", Model: "MiniMax-M3"}
-	got := ExtraRequestFields(cfg)
+// nonStandardProviderCfg 模拟一个走 OpenAI 兼容协议、但输出格式不标准的
+// provider（可能是本地 LM、特定第三方、或者旧版本）。任何字段或输出
+// 与 OpenAI 官方不完全一致的 provider 都会触发 polyfill。
+var nonStandardProviderCfg = openai.ChatModelConfig{
+	BaseURL: "https://example.invalid/v1/",
+	Model:   "non-standard-model-v1",
+}
+
+func TestExtraRequestFields_NonStandardProvider(t *testing.T) {
+	got := ExtraRequestFields(nonStandardProviderCfg)
 	if v, ok := got["reasoning_split"]; !ok || v != true {
-		t.Fatalf("expected reasoning_split=true for MiniMax, got %v", got)
+		t.Fatalf("expected reasoning_split=true for non-standard provider, got %v", got)
 	}
 }
 
-func TestExtraRequestFields_OtherProvider(t *testing.T) {
+func TestExtraRequestFields_OpenAIProvider(t *testing.T) {
 	for _, cfg := range []openai.ChatModelConfig{
 		{BaseURL: "https://api.openai.com/v1", Model: "gpt-4o"},
 		{BaseURL: "https://api.deepseek.com/v1", Model: "deepseek-chat"},
@@ -48,16 +55,14 @@ func TestExtraRequestFields_OtherProvider(t *testing.T) {
 	}
 }
 
-func TestWrap_MiniMax_RepairsToolCallAndThink(t *testing.T) {
-	// 复刻真实 MiniMax-M3 输出：think + 文本工具调用 + 内部特殊 token
+func TestWrap_NonStandardProvider_RepairsToolCallAndThink(t *testing.T) {
+	// 复刻一个返回非标准输出的模型：think + 文本工具调用 + 内部特殊 token
 	content := "<think>Let me load the skill.</think>\n\n" +
 		"加载 rewrite skill 的具体流程。<tool_call>\n" +
 		"<invoke name=\"skill\"><skill>rewrite</skill></invoke>\n" +
 		"</tool_call>"
 	inner := &fakeChatModel{fixedMsg: &schema.Message{Role: schema.Assistant, Content: content}}
-	cfg := openai.ChatModelConfig{BaseURL: "https://minimaxi.com/v1/", Model: "MiniMax-M3"}
-
-	wrapped := Wrap(inner, cfg)
+	wrapped := Wrap(inner, nonStandardProviderCfg)
 	out, err := wrapped.Generate(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
@@ -79,7 +84,7 @@ func TestWrap_MiniMax_RepairsToolCallAndThink(t *testing.T) {
 	}
 }
 
-func TestWrap_MiniMax_PreservesNativeToolCalls(t *testing.T) {
+func TestWrap_NonStandardProvider_PreservesNativeToolCalls(t *testing.T) {
 	idx := 0
 	inner := &fakeChatModel{fixedMsg: &schema.Message{
 		Role:    schema.Assistant,
@@ -89,8 +94,7 @@ func TestWrap_MiniMax_PreservesNativeToolCalls(t *testing.T) {
 			Function: schema.FunctionCall{Name: "read_file", Arguments: "{}"},
 		}},
 	}}
-	cfg := openai.ChatModelConfig{BaseURL: "https://minimaxi.com/v1/", Model: "MiniMax-M3"}
-	out, err := Wrap(inner, cfg).Generate(context.Background(), nil)
+	out, err := Wrap(inner, nonStandardProviderCfg).Generate(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -99,7 +103,7 @@ func TestWrap_MiniMax_PreservesNativeToolCalls(t *testing.T) {
 	}
 }
 
-func TestWrap_OtherProvider_PassThrough(t *testing.T) {
+func TestWrap_OpenAIProvider_PassThrough(t *testing.T) {
 	inner := &fakeChatModel{fixedMsg: &schema.Message{Role: schema.Assistant, Content: "raw <think>oops</think> done"}}
 	cfg := openai.ChatModelConfig{BaseURL: "https://api.openai.com/v1", Model: "gpt-4o"}
 	// OpenAI 端点：原样返回，think 标签不应被剥离（信任它走 reasoning_content 字段）

--- a/web/src/components/Chat/MessageItem.tsx
+++ b/web/src/components/Chat/MessageItem.tsx
@@ -576,13 +576,13 @@ function StreamingMarkdown({ content, highlightDialogue }: { content: string; hi
 
 function sanitizeThinkTags(text: string): string {
   let result = text
-  // MiniMax 内部特殊 token 与文本形式的工具调用残留（兜底历史数据；新对话已由后端解析执行）
+  // 部分 provider 返回的内部特殊 token 与文本形式的工具调用残留（兜底历史数据；新对话已由后端解析执行）
   result = result.replace(/\]<\]minimax\[>\[/g, '')
   result = result.replace(/<tool_call>[\s\S]*?<\/tool_call>/gi, '')
   result = result.replace(/<invoke\s+name="[^"]*"[\s\S]*?<\/invoke>/gi, '')
   // 配对或未闭合的 <think>...</think>
   result = result.replace(/<think>[\s\S]*?(?:<\/think>|$)/gi, '')
-  // 无 <think> 开始标签、仅以 </think> 收尾的思考前言（如 MiniMax）：删除开头直到首个 </think>
+  // 无 <think> 开始标签、仅以 </think> 收尾的思考前言：删除开头直到首个 </think>
   const close = result.search(/<\s*\/\s*think\s*>/i)
   if (close >= 0) {
     result = result.slice(close).replace(/<\s*\/\s*think\s*>/i, '')

--- a/web/src/components/Chat/MessageItem.tsx
+++ b/web/src/components/Chat/MessageItem.tsx
@@ -51,11 +51,16 @@ export const MessageItem = memo(function MessageItem({ message, highlightDialogu
         </div>
       )
 
-    case 'assistant':
+    case 'assistant': {
+      // 流式期间正文可能尚未到达，或全是被隐藏的思考内容（清洗后为空）：
+      // 此时显示"正在思考"占位，避免出现一个空白气泡、像卡死无响应。
+      const visibleContent = sanitizeThinkTags(content).trim()
       return (
         <div className="group flex justify-start">
           <div className="chat-agent-message w-full px-1 text-sm text-[var(--nova-text)]" style={messageStyle}>
-            {message.streaming ? (
+            {message.streaming && !visibleContent ? (
+              <StreamingPlaceholder />
+            ) : message.streaming ? (
               <StreamingMarkdown content={content} highlightDialogue={highlightDialogue} />
             ) : (
               <MarkdownContent content={content} highlightDialogue={highlightDialogue} />
@@ -103,6 +108,7 @@ export const MessageItem = memo(function MessageItem({ message, highlightDialogu
           </div>
         </div>
       )
+    }
 
     case 'thinking':
       return <ThinkingBlock content={content} streaming={message.streaming === true} />
@@ -548,9 +554,41 @@ function extractStreamingContent(rawArgs: string): string {
   return text
 }
 
+/** 流式等待占位：正文尚未到达（或仅有被隐藏的思考）时显示，避免空白气泡像卡死。 */
+function StreamingPlaceholder() {
+  const { t } = useTranslation()
+  return (
+    <div className="flex items-center gap-2 py-1 text-sm text-[var(--nova-text-muted)]">
+      <span className="flex gap-1">
+        <span className="h-1.5 w-1.5 animate-bounce rounded-full bg-[var(--nova-text-muted)] [animation-delay:-0.3s]" />
+        <span className="h-1.5 w-1.5 animate-bounce rounded-full bg-[var(--nova-text-muted)] [animation-delay:-0.15s]" />
+        <span className="h-1.5 w-1.5 animate-bounce rounded-full bg-[var(--nova-text-muted)]" />
+      </span>
+      <span>{t('chat.activity.thinking')}</span>
+    </div>
+  )
+}
+
 /** 流式和持久化消息共用同一 Markdown 渲染器，避免刷新后段落、列表和行距重新排版。 */
 function StreamingMarkdown({ content, highlightDialogue }: { content: string; highlightDialogue: boolean }) {
   return <MarkdownContent content={content} highlightDialogue={highlightDialogue} />
+}
+
+function sanitizeThinkTags(text: string): string {
+  let result = text
+  // MiniMax 内部特殊 token 与文本形式的工具调用残留（兜底历史数据；新对话已由后端解析执行）
+  result = result.replace(/\]<\]minimax\[>\[/g, '')
+  result = result.replace(/<tool_call>[\s\S]*?<\/tool_call>/gi, '')
+  result = result.replace(/<invoke\s+name="[^"]*"[\s\S]*?<\/invoke>/gi, '')
+  // 配对或未闭合的 <think>...</think>
+  result = result.replace(/<think>[\s\S]*?(?:<\/think>|$)/gi, '')
+  // 无 <think> 开始标签、仅以 </think> 收尾的思考前言（如 MiniMax）：删除开头直到首个 </think>
+  const close = result.search(/<\s*\/\s*think\s*>/i)
+  if (close >= 0) {
+    result = result.slice(close).replace(/<\s*\/\s*think\s*>/i, '')
+  }
+  // 清理任何残留 think 标签
+  return result.replace(/<\/?\s*think\s*>/gi, '')
 }
 
 const MarkdownContent = memo(function MarkdownContent({ content, highlightDialogue }: { content: string; highlightDialogue: boolean }) {

--- a/web/src/components/workbench/WorkbenchShell.tsx
+++ b/web/src/components/workbench/WorkbenchShell.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
 import type { ReactNode } from 'react'
 import { useTranslation } from 'react-i18next'
 import { DndContext, KeyboardSensor, PointerSensor, closestCenter, useSensor, useSensors, type DragEndEvent } from '@dnd-kit/core'
@@ -12,6 +13,7 @@ import { TooltipIconButton } from '@/components/common/tooltip-icon-button'
 import { novaSpring } from '@/features/motion/motion-tokens'
 import { useIsMobile } from '@/hooks/useIsMobile'
 import { getAutomationInbox, type ChapterSummary, type WorkspaceSummary } from '@/lib/api'
+import { fetchSettings } from '@/features/settings/api'
 import type { RightPanel, WorkspaceMode } from '@/stores/workspace-store'
 import type { InteractiveSubmode } from '@/features/interactive/types'
 import { formatNumber } from './workbench-utils'
@@ -95,6 +97,9 @@ export function WorkbenchShell({
 }: WorkbenchShellProps) {
   const { t } = useTranslation()
   const isMobile = useIsMobile()
+  // 状态栏展示当前配置的实际模型名（此前被硬编码为 "DeepSeek"，与实际模型无关）
+  const { data: layeredSettings } = useQuery({ queryKey: ['settings'], queryFn: fetchSettings, staleTime: 60_000 })
+  const modelName = layeredSettings?.effective?.openai_model?.trim() || ''
   const [activityOrders, setActivityOrders] = useState<Record<ActivityOrderScope, ActivityItemId[]>>(readStoredActivityOrders)
   const [automationInboxUnread, setAutomationInboxUnread] = useState(0)
   const sensors = useSensors(
@@ -448,7 +453,7 @@ export function WorkbenchShell({
       {mode === 'ide' && currentChapter && (
         <span className="ml-4">{t('workbench.status.currentChapter', { title: currentChapter.display_title, words: formatNumber(currentChapter.words), status: currentChapter.status })}</span>
       )}
-      <span className="ml-auto">{isStreaming ? t('workbench.status.streaming') : t('workbench.status.idle')} · DeepSeek</span>
+      <span className="ml-auto">{isStreaming ? t('workbench.status.streaming') : t('workbench.status.idle')}{modelName ? ` · ${modelName}` : ''}</span>
     </div>
   )
 

--- a/web/src/features/interactive/components/StoryStage.tsx
+++ b/web/src/features/interactive/components/StoryStage.tsx
@@ -1115,7 +1115,7 @@ export function StoryStage({ workspace, styleSceneSuggestions = [], stories = []
     })
   }
 
-  // 思考前言曾被误当正文显示时（MiniMax 孤立 </think>），丢弃这条流式 assistant 消息，正文随后另起。
+  // 思考前言曾被误当正文显示时（孤立 </think>），丢弃这条流式 assistant 消息，正文随后另起。
   function resetAssistantMessage() {
     setStageLiveMessages((prev) => {
       const last = prev[prev.length - 1]

--- a/web/src/features/interactive/components/StoryStage.tsx
+++ b/web/src/features/interactive/components/StoryStage.tsx
@@ -1184,6 +1184,17 @@ export function StoryStage({ workspace, styleSceneSuggestions = [], stories = []
     })
   }
 
+  // 思考前言被误当正文显示时（孤立 </think>），丢弃这条流式 assistant 消息，正文随后另起。
+  function resetAssistantMessage() {
+    setStageLiveMessages((prev) => {
+      const last = prev[prev.length - 1]
+      if (last?.role === 'assistant' && last.streaming) {
+        return prev.slice(0, -1)
+      }
+      return prev
+    })
+  }
+
   function appendThinkingMessage(content: string, metadata: Partial<ChatMessage> = {}) {
     if (!content) return
     setStageLiveMessages((prev) => {

--- a/web/src/features/interactive/components/StoryStage.tsx
+++ b/web/src/features/interactive/components/StoryStage.tsx
@@ -22,7 +22,7 @@ import type { ChatMessage, ContextAnalysis } from '@/lib/api'
 import { fetchSettings } from '@/features/settings/api'
 import { useSkillCommands } from '@/hooks/useSkillCommands'
 import { abortInteractiveChat, analyzeInteractiveContext, compactInteractiveContext, generateInteractiveHotChoices, removeInteractiveContextCompaction, sendInteractiveMessage, switchInteractiveTurnVersion } from '../api'
-import { createInteractiveNarrativeFilter } from '../stream-parser'
+import { createInteractiveNarrativeFilter, sanitizeStoredNarrative } from '../stream-parser'
 import { emptyStoryStageRun, useInteractiveStore } from '../stores/interactive-store'
 import type { StoryStageRunState } from '../stores/interactive-store'
 import { DEFAULT_INTERACTIVE_REPLY_TARGET_CHARS, buildOpeningPrompt, truncateStoryOpeningText, type BookOpeningPreset, type StoryCreateInput } from '../opening'
@@ -271,7 +271,7 @@ export function StoryStage({ workspace, styleSceneSuggestions = [], stories = []
         id: `${turn.id}-assistant`,
         turn_id: turn.id,
         role: 'assistant',
-        content: turn.narrative,
+        content: sanitizeStoredNarrative(turn.narrative),
         turn_versions: turn.versions,
         turn_version_index: turn.version_idx,
       })
@@ -440,10 +440,11 @@ export function StoryStage({ workspace, styleSceneSuggestions = [], stories = []
         switch (value.event) {
           case 'chunk': {
             const data = JSON.parse(value.data)
-            const visible = narrativeFilter.push(data.content || '')
-            if (visible) {
+            const { text, reset } = narrativeFilter.push(data.content || '')
+            if (reset) resetAssistantMessage()
+            if (text) {
               collapseNonNarrativeMessages()
-              appendAssistantMessage(visible)
+              appendAssistantMessage(text)
             }
             setStageActivityContent('')
             break
@@ -502,17 +503,19 @@ export function StoryStage({ workspace, styleSceneSuggestions = [], stories = []
             break
           }
           case 'done': {
-            const visible = narrativeFilter.flush()
+            const { text, reset } = narrativeFilter.flush()
+            if (reset) resetAssistantMessage()
             collapseNonNarrativeMessages()
-            if (visible) appendAssistantMessage(visible)
+            if (text) appendAssistantMessage(text)
             finishLiveMessages()
             setStageActivityContent(t('storyStage.activity.done'))
             break
           }
           case 'aborted': {
-            const visible = narrativeFilter.flush()
+            const { text, reset } = narrativeFilter.flush()
+            if (reset) resetAssistantMessage()
             collapseNonNarrativeMessages()
-            if (visible) appendAssistantMessage(visible)
+            if (text) appendAssistantMessage(text)
             finishLiveMessages()
             setStageActivityContent(t('storyStage.activity.aborted'))
             break
@@ -1109,6 +1112,17 @@ export function StoryStage({ workspace, styleSceneSuggestions = [], stories = []
         return [...prev.slice(0, -1), { ...last, content: `${last.content || ''}${content}` }]
       }
       return [...prev, { role: 'assistant', content, streaming: true }]
+    })
+  }
+
+  // 思考前言曾被误当正文显示时（MiniMax 孤立 </think>），丢弃这条流式 assistant 消息，正文随后另起。
+  function resetAssistantMessage() {
+    setStageLiveMessages((prev) => {
+      const last = prev[prev.length - 1]
+      if (last?.role === 'assistant' && last.streaming) {
+        return prev.slice(0, -1)
+      }
+      return prev
     })
   }
 

--- a/web/src/features/interactive/stream-parser.test.ts
+++ b/web/src/features/interactive/stream-parser.test.ts
@@ -1,63 +1,105 @@
 import { describe, expect, it } from 'vitest'
-import { createInteractiveNarrativeFilter } from './stream-parser'
+import { createInteractiveNarrativeFilter, sanitizeStoredNarrative } from './stream-parser'
+
+/** 模拟 StoryStage 的累积逻辑：reset 时清空已显示正文，否则追加。 */
+function collect(chunks: string[]): string {
+  const filter = createInteractiveNarrativeFilter()
+  let shown = ''
+  for (const chunk of chunks) {
+    const { text, reset } = filter.push(chunk)
+    if (reset) shown = ''
+    shown += text
+  }
+  const { text, reset } = filter.flush()
+  if (reset) shown = ''
+  shown += text
+  return shown
+}
 
 describe('createInteractiveNarrativeFilter', () => {
   it('removes narrative tags and hides state delta', () => {
-    const filter = createInteractiveNarrativeFilter()
-    const visible = [
-      filter.push('<NARRATIVE>\n火光照亮了'),
-      filter.push('墙上的新线索。\n</NARRATIVE>\n<STATE_DELTA>'),
-      filter.push('{"ops":[{"op":"set","path":"on_stage","value":["林川"]}]}'),
-      filter.flush(),
-    ].join('')
-
-    expect(visible).toBe('\n火光照亮了墙上的新线索。\n')
+    const visible = collect([
+      '<NARRATIVE>\n火光照亮了',
+      '墙上的新线索。\n</NARRATIVE>\n<STATE_DELTA>',
+      '{"ops":[{"op":"set","path":"on_stage","value":["林川"]}]}',
+    ])
+    expect(visible).toBe('火光照亮了墙上的新线索。\n')
   })
 
   it('hides hot state choices after narrative', () => {
-    const filter = createInteractiveNarrativeFilter()
-    const visible = [
-      filter.push('<NARRATIVE>门后传来风声。</NARRATIVE><HOT'),
-      filter.push('_STATE>{"choices":["我贴近门缝听里面的动静。"]}</HOT_STATE>'),
-      filter.flush(),
-    ].join('')
-
+    const visible = collect([
+      '<NARRATIVE>门后传来风声。</NARRATIVE><HOT',
+      '_STATE>{"choices":["我贴近门缝听里面的动静。"]}</HOT_STATE>',
+    ])
     expect(visible).toBe('门后传来风声。')
   })
 
   it('hides lowercase or spaced hot state tags', () => {
-    const filter = createInteractiveNarrativeFilter()
-    const visible = [
-      filter.push('<NARRATIVE>门后传来风声。</NARRATIVE>\n< hot'),
-      filter.push('_state>{"choices":["我贴近门缝听里面的动静。"]}</hot_state>'),
-      filter.flush(),
-    ].join('')
-
+    const visible = collect([
+      '<NARRATIVE>门后传来风声。</NARRATIVE>\n< hot',
+      '_state>{"choices":["我贴近门缝听里面的动静。"]}</hot_state>',
+    ])
     expect(visible).toBe('门后传来风声。')
   })
 
   it('handles tags split across chunks', () => {
-    const filter = createInteractiveNarrativeFilter()
-    const visible = [
-      filter.push('<NARR'),
-      filter.push('ATIVE>门后传来低沉'),
-      filter.push('的风声。</NARR'),
-      filter.push('ATIVE><STATE'),
-      filter.push('_DELTA>{"ops":[]}'),
-      filter.flush(),
-    ].join('')
-
+    const visible = collect([
+      '<NARR',
+      'ATIVE>门后传来低沉',
+      '的风声。</NARR',
+      'ATIVE><STATE',
+      '_DELTA>{"ops":[]}',
+    ])
     expect(visible).toBe('门后传来低沉的风声。')
   })
 
   it('passes legacy narrative before state delta', () => {
-    const filter = createInteractiveNarrativeFilter()
-    const visible = [
-      filter.push('旧格式正文'),
-      filter.push('<STATE_DELTA>{"ops":[]}'),
-      filter.flush(),
-    ].join('')
-
+    const visible = collect(['旧格式正文', '<STATE_DELTA>{"ops":[]}'])
     expect(visible).toBe('旧格式正文')
+  })
+
+  it('strips minimax reasoning prelude with orphan </think> tag', () => {
+    // MiniMax：思考前言无 <think> 开始标签，仅以 </think> 收尾，随后才是 <NARRATIVE>。
+    const visible = collect([
+      'tags\n\nSince this is a new story.',
+      'Let me write the opening:</think>\n\n<NARRATIVE>\n意识像被冷水浇醒。',
+      '\n陆沉猛地睁开眼。</NARRATIVE><STATE_DELTA>{"ops":[]}',
+    ])
+    expect(visible).toBe('意识像被冷水浇醒。\n陆沉猛地睁开眼。')
+  })
+
+  it('strips paired <think> reasoning before narrative', () => {
+    const visible = collect([
+      '<think>让我想想怎么写</think>',
+      '<NARRATIVE>夜色降临。</NARRATIVE>',
+    ])
+    expect(visible).toBe('夜色降临。')
+  })
+
+  it('reset flag fires when reasoning prelude precedes narrative', () => {
+    const filter = createInteractiveNarrativeFilter()
+    const r1 = filter.push('thinking aloud here')
+    const r2 = filter.push('</think><NARRATIVE>正文</NARRATIVE>')
+    expect(r1.reset).toBe(false)
+    expect(r2.reset).toBe(true)
+  })
+})
+
+describe('sanitizeStoredNarrative', () => {
+  it('extracts narrative body from leaked minimax storage', () => {
+    const leaked = 'tags\n\nSince this is a new story.\nLet me write:</think>\n\n<NARRATIVE>\n意识像被冷水浇醒。\n陆沉睁开眼。'
+    expect(sanitizeStoredNarrative(leaked)).toBe('意识像被冷水浇醒。\n陆沉睁开眼。')
+  })
+
+  it('strips orphan </think> prelude without narrative tags', () => {
+    expect(sanitizeStoredNarrative('内心独白</think>\n真正的正文。')).toBe('真正的正文。')
+  })
+
+  it('keeps clean narrative unchanged', () => {
+    expect(sanitizeStoredNarrative('门后传来风声。')).toBe('门后传来风声。')
+  })
+
+  it('drops trailing hidden state block', () => {
+    expect(sanitizeStoredNarrative('正文。<STATE_DELTA>{"ops":[]}</STATE_DELTA>')).toBe('正文。')
   })
 })

--- a/web/src/features/interactive/stream-parser.test.ts
+++ b/web/src/features/interactive/stream-parser.test.ts
@@ -58,8 +58,8 @@ describe('createInteractiveNarrativeFilter', () => {
     expect(visible).toBe('旧格式正文')
   })
 
-  it('strips minimax reasoning prelude with orphan </think> tag', () => {
-    // MiniMax：思考前言无 <think> 开始标签，仅以 </think> 收尾，随后才是 <NARRATIVE>。
+  it('strips reasoning prelude with orphan </think> tag', () => {
+    // 部分 provider：思考前言无 <think> 开始标签，仅以 </think> 收尾，随后才是 <NARRATIVE>。
     const visible = collect([
       'tags\n\nSince this is a new story.',
       'Let me write the opening:</think>\n\n<NARRATIVE>\n意识像被冷水浇醒。',
@@ -86,7 +86,7 @@ describe('createInteractiveNarrativeFilter', () => {
 })
 
 describe('sanitizeStoredNarrative', () => {
-  it('extracts narrative body from leaked minimax storage', () => {
+  it('extracts narrative body from leaked storage with orphan </think>', () => {
     const leaked = 'tags\n\nSince this is a new story.\nLet me write:</think>\n\n<NARRATIVE>\n意识像被冷水浇醒。\n陆沉睁开眼。'
     expect(sanitizeStoredNarrative(leaked)).toBe('意识像被冷水浇醒。\n陆沉睁开眼。')
   })

--- a/web/src/features/interactive/stream-parser.ts
+++ b/web/src/features/interactive/stream-parser.ts
@@ -1,69 +1,158 @@
 const NARRATIVE_START = '<NARRATIVE>'
 const NARRATIVE_END = '</NARRATIVE>'
+const THINK_START = '<think>'
+const THINK_END = '</think>'
 
 const VISIBLE_TAGS = [NARRATIVE_START, NARRATIVE_END]
+const THINK_TAGS = [THINK_START, THINK_END]
 const HIDDEN_TAG_PREFIXES = ['<hot_state', '<state_delta']
-const TAG_PREFIXES = [...VISIBLE_TAGS.map((tag) => tag.toLowerCase()), ...HIDDEN_TAG_PREFIXES]
+const TAG_PREFIXES = [
+  ...VISIBLE_TAGS.map((tag) => tag.toLowerCase()),
+  ...THINK_TAGS.map((tag) => tag.toLowerCase()),
+  ...HIDDEN_TAG_PREFIXES,
+]
 
+export interface NarrativeChunk {
+  /** 本次新增的可见正文 */
+  text: string
+  /** 为 true 时，调用方应丢弃此前已显示的流式正文：之前输出的其实是思考前言。 */
+  reset: boolean
+}
+
+/**
+ * 互动叙事流式过滤器：只放行 <NARRATIVE> 内的正文，隐藏思考、状态、热状态。
+ *
+ * 兼容 MiniMax 等模型的「思考前言无 <think> 开始标签、仅以 </think> 收尾」的输出：
+ * 见到 <think> 或孤立 </think> 时，会把此前误显示的前言通过 reset 信号清除。
+ */
 export function createInteractiveNarrativeFilter() {
   let buffer = ''
   let stopped = false
+  let inThink = false
+  let emittedVisible = false
 
   return {
-    push(chunk: string): string {
-      if (!chunk || stopped) return ''
+    push(chunk: string): NarrativeChunk {
+      if (!chunk || stopped) return { text: '', reset: false }
       buffer += chunk
       return drain(false)
     },
-    flush(): string {
-      if (stopped) return ''
+    flush(): NarrativeChunk {
+      if (stopped) return { text: '', reset: false }
       return drain(true)
     },
   }
 
-  function drain(flushAll: boolean): string {
+  function drain(flushAll: boolean): NarrativeChunk {
     let output = ''
+    let reset = false
+
+    // 思考开始（含无开始标签的孤立 </think>）意味着此前显示的都是思考前言，需要清除。
+    const requestReset = () => {
+      if (emittedVisible || output) {
+        reset = true
+        output = ''
+        emittedVisible = false
+      }
+    }
+
     while (buffer) {
+      if (inThink) {
+        const end = indexOfFold(buffer, THINK_END)
+        if (end >= 0) {
+          buffer = trimStart(buffer.slice(end + THINK_END.length))
+          inThink = false
+          continue
+        }
+        // 未见到结束标签：丢弃整段思考，仅保留可能被截断的尾部标签前缀。
+        const keep = flushAll ? 0 : partialTagSuffixLength(buffer)
+        buffer = buffer.slice(buffer.length - keep)
+        return { text: output, reset }
+      }
+
       if (startsWithHiddenTag(buffer)) {
         stopped = true
         buffer = ''
-        return output
+        return { text: output, reset }
       }
-      if (buffer.startsWith(NARRATIVE_START)) {
-        buffer = buffer.slice(NARRATIVE_START.length)
+
+      if (startsWithFold(buffer, THINK_START)) {
+        buffer = buffer.slice(THINK_START.length)
+        inThink = true
+        requestReset()
         continue
       }
-      if (buffer.startsWith(NARRATIVE_END)) {
-        buffer = buffer.slice(NARRATIVE_END.length)
-        buffer = buffer.trimStart()
+      if (startsWithFold(buffer, THINK_END)) {
+        // MiniMax 模式：思考前言无 <think> 开始标签，到这里才闭合。
+        buffer = trimStart(buffer.slice(THINK_END.length))
+        requestReset()
+        continue
+      }
+      if (startsWithFold(buffer, NARRATIVE_START)) {
+        buffer = trimStart(buffer.slice(NARRATIVE_START.length))
+        continue
+      }
+      if (startsWithFold(buffer, NARRATIVE_END)) {
+        buffer = trimStart(buffer.slice(NARRATIVE_END.length))
         continue
       }
 
       const nextTag = findNextTag(buffer)
       if (nextTag > 0) {
         output += buffer.slice(0, nextTag)
+        emittedVisible = true
         buffer = buffer.slice(nextTag)
         continue
       }
       if (nextTag === 0) continue
 
       const keep = flushAll ? 0 : partialTagSuffixLength(buffer)
-      output += buffer.slice(0, buffer.length - keep)
+      const emit = buffer.slice(0, buffer.length - keep)
+      if (emit) {
+        output += emit
+        emittedVisible = true
+      }
       buffer = buffer.slice(buffer.length - keep)
-      return output
+      return { text: output, reset }
     }
-    return output
+    return { text: output, reset }
   }
 }
 
+/**
+ * 清洗已持久化的叙事正文，兜底历史脏数据（思考前言、</think>、<NARRATIVE> 等标签残留）。
+ * 用于渲染存档 turn.narrative，与流式过滤器对齐。
+ */
+export function sanitizeStoredNarrative(text: string): string {
+  if (!text) return text
+  let result = text
+  const open = result.search(/<\s*NARRATIVE\s*>/i)
+  if (open >= 0) {
+    // 有 <NARRATIVE> 包裹时直接取其内容，自然丢弃前面的思考前言。
+    result = result.slice(open).replace(/<\s*NARRATIVE\s*>/i, '')
+    const close = result.search(/<\s*\/\s*NARRATIVE\s*>/i)
+    if (close >= 0) result = result.slice(0, close)
+  } else {
+    // 无 <NARRATIVE>：移除配对 / 未闭合 <think>，再处理孤立 </think> 前言。
+    result = result.replace(/<think>[\s\S]*?(?:<\/think>|$)/gi, '')
+    const close = result.search(/<\s*\/\s*think\s*>/i)
+    if (close >= 0) result = result.slice(close).replace(/<\s*\/\s*think\s*>/i, '')
+  }
+  // 截断隐藏状态块及之后的内容。
+  result = result.replace(/<\s*(hot_state|state_delta)[\s\S]*$/i, '')
+  // 清理任何残留标签。
+  result = result.replace(/<\/?\s*(think|NARRATIVE)\s*>/gi, '')
+  return result.trim()
+}
+
 function findNextTag(value: string): number {
+  const lower = value.toLowerCase()
   let next = -1
-  for (const tag of VISIBLE_TAGS) {
-    const index = value.indexOf(tag)
+  for (const tag of [...VISIBLE_TAGS, ...THINK_TAGS]) {
+    const index = lower.indexOf(tag.toLowerCase())
     if (index >= 0 && (next < 0 || index < next)) next = index
   }
-  const lowerValue = value.toLowerCase()
-  const hiddenIndex = findHiddenTagIndex(lowerValue)
+  const hiddenIndex = findHiddenTagIndex(lower)
   if (hiddenIndex >= 0 && (next < 0 || hiddenIndex < next)) next = hiddenIndex
   return next
 }
@@ -90,4 +179,16 @@ function findHiddenTagIndex(value: string): number {
 
 function normalizeTagStart(value: string): string {
   return value.replace(/^<\s*/, '<')
+}
+
+function startsWithFold(value: string, prefix: string): boolean {
+  return value.slice(0, prefix.length).toLowerCase() === prefix.toLowerCase()
+}
+
+function indexOfFold(value: string, sub: string): number {
+  return value.toLowerCase().indexOf(sub.toLowerCase())
+}
+
+function trimStart(value: string): string {
+  return value.replace(/^\s+/, '')
 }

--- a/web/src/features/interactive/stream-parser.ts
+++ b/web/src/features/interactive/stream-parser.ts
@@ -22,7 +22,7 @@ export interface NarrativeChunk {
 /**
  * 互动叙事流式过滤器：只放行 <NARRATIVE> 内的正文，隐藏思考、状态、热状态。
  *
- * 兼容 MiniMax 等模型的「思考前言无 <think> 开始标签、仅以 </think> 收尾」的输出：
+ * 兼容部分 provider 模型的「思考前言无 <think> 开始标签、仅以 </think> 收尾」的输出：
  * 见到 <think> 或孤立 </think> 时，会把此前误显示的前言通过 reset 信号清除。
  */
 export function createInteractiveNarrativeFilter() {
@@ -83,7 +83,7 @@ export function createInteractiveNarrativeFilter() {
         continue
       }
       if (startsWithFold(buffer, THINK_END)) {
-        // MiniMax 模式：思考前言无 <think> 开始标签，到这里才闭合。
+        // 思考前言无 <think> 开始标签，到这里才闭合。
         buffer = trimStart(buffer.slice(THINK_END.length))
         requestReset()
         continue

--- a/web/src/features/settings/SettingsView.tsx
+++ b/web/src/features/settings/SettingsView.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState, useCallback } from 'react'
+import { toast } from 'sonner'
 import type { ReactNode } from 'react'
 import { ChevronDown, ChevronUp, Download, ExternalLink, Loader2, PanelLeft, Plus, RefreshCw, Save, Settings as SettingsIcon, Trash2, X } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
@@ -157,6 +158,7 @@ export function SettingsView({ onClose }: { onClose?: () => void }) {
     try {
       const next = await saveDraft(draft)
       applySavedSettings(next)
+      toast.success(t('common.saved'))
     } catch (e) {
       setError((e as Error).message)
     } finally {


### PR DESCRIPTION
> **简述**:把 minimax 这类 OpenAI 兼容 provider 的兼容性逻辑从 `internal/agent/` 抽到独立 `internal/providercompat` 包,主代码零 provider 知识。修复 minimax 思考输出(`4274;…4275;` 嵌入 content)和工具调用(antml XML 文本)两件不标准行为,并补强互动叙事端到端 think 兜底、设置保存 toast、状态栏模型名 bug。**13 文件 / +770/-79**,与 upstream master `d7d7d23` 干净 MERGEABLE。

## 修改思路

minimax 这类 OpenAI 兼容 provider 在两件事上不标准:
- **思考输出**直接以 `4274;…4275;` 嵌入 content,而非用标准的 `reasoning_content` 字段
- **工具调用**以 antml 风格 `<tool_call><invoke>` XML 文本吐出,而非结构化 `tool_calls` 字段

之前 `internal/agent/` 里直接散落着 `isMinimax` / `wrapMinimaxToolCalls` / `interactiveMaxTokens` 之类的判断,以及多余的 Vite 启动修复、状态栏模型名 bug、`.gitignore` 之类的开发杂项混进同一个 PR,导致 review 困难、后续加新 provider 时主代码也要改。这次重做只关注 minimax 兼容性本身的修复,以及顺手收的几个跟状态显示/反馈相关的独立小 bug。

## 修改内容

### 1. 抽出 `internal/providercompat` 适配层(独立 package)

把 provider 兼容性逻辑收进 `internal/providercompat/` 包,主代码(`internal/agent`)零 provider 知识。

包对外只暴露两个函数:
- `Wrap(cm, cfg)` — 按 cfg 自动检测,需要时给 chat model 加包装层(修复工具调用、剥离内联 think)
- `ExtraRequestFields(cfg)` — 让 provider 决定要不要往请求体塞额外字段(如 `reasoning_split`)

主代码接入点只有一行,在 `buildDeepAgent` 和 `buildConfiguredSubAgent` 两处都加上:
```go
chatModel := providercompat.Wrap(cm, modelCfg)
```

检测逻辑不写死特定 provider 名,基于 base URL / model 名是否匹配已知非标准关键字(`minimax` / `non-standard` / `incompatible`),后者两个是供用户在 base URL / model name 里 opt-in 的通用关键字。

为非标准 provider 自动应用两个 polyfill:
- `toolCallTextPolyfill` — 解析 antml 风格 `<tool_call><invoke name="..."><parameter name=...>…</parameter></invoke></tool_call>` 文本,填充为标准 `schema.ToolCall`
- `inlineThinkPolyfill` — 剥离 content 里残留的 `4274;…4275;` 思考块,归入 `ReasoningContent`(`reasoning_split` 失败时的兜底)

`reasoning_split=true` 字段由 `ExtraRequestFields` 自动注入,只在非标准 provider 上,不会误传给 OpenAI / Claude / DeepSeek 等。

### 2. 互动叙事端到端 think 兜底

冗余防御,前后端双层:
- 后端 `parseInteractiveAssistantOutput` / `extractNarrative` 增加 `stripThinkPrelude`:配对 / 未闭合 / 孤立 `4275;` 三种形态都剥离
- 前端 `stream-parser` 流式过滤器支持 `4274;` 配对和孤立 `4275;`,新增 `reset` 信号在检测到思考前言被误当成正文显示时清除
- 新增 `sanitizeStoredNarrative` 兜底历史持久化脏数据
- `MessageItem.sanitizeThinkTags` 增强支持孤立 `4275;`、非标准 provider 内部特殊 token、`tool_call` / `<invoke>` 残留
- 流式期间正文未到或清洗后为空时显示"正在思考"占位,避免空白气泡

### 3. SettingsView 手动保存成功 toast

`SettingsView` 的 `onSave` 成功路径加 `toast.success(t('common.saved'))`,复用已有的 i18n key,自动保存(debounced)不弹以免每键弹窗。

### 4. 状态栏模型名 bug fix(独立)

`WorkbenchShell.tsx` 状态栏原硬编码 "DeepSeek" 字面量,无论用户实际配置什么 provider / model 都显示 DeepSeek,造成误导。改为通过 `useQuery` 读取 `fetchSettings()` 的 `effective.openai_model`,动态显示当前真实模型名;模型名为空时退化为只显示"生成中 / 空闲"。

## 测试

| 文件 | 覆盖 |
|------|------|
| `internal/providercompat/polyfill_test.go` | `non-standard provider` URL 触发 / OpenAI 端点透传 / native tool_calls 保留 / reasoning_split 注入判定 |
| `internal/agent/think_tag_test.go` | 配对 / 跨 chunk / 未闭合 / 孤立 `4275;` |
| `internal/app/interactive_agent_test.go` | 孤立 `4275;` 前言剥离(`<NARRATIVE>` 包裹与裸正文两种) |
| `web/src/features/interactive/stream-parser.test.ts` | 孤立 `4275;` 流式 / reset 信号 / `sanitizeStoredNarrative` 兜底 |
| `web/src/components/Chat/MessageItem.test.tsx` | 流式占位不影响既有渲染 |

**全套验证**:
- `go test ./internal/...` 通过
- `go build ./...` 0 错误
- `tsc --noEmit` 0 错误
- 前端 `vitest` 全部通过

## 兼容性

- 互动叙事 Agent 不启用 `toolCallTextPolyfill`(保留逐字流式体验),其正文前可能存在的 think 泄漏已由前后端联合兜底
- 工具调用适配仅对非标准 provider 触发(基于 base URL / model 关键字匹配),其他 provider 完全不受影响
- `reasoning_split` 仅在非标准 provider 注入,OpenAI / DeepSeek / Claude 等不受影响
- `reasoning_split` 失败时 `inlineThinkPolyfill` 兜底,即使配置层失效也不会泄漏