### PR TITLE
fix: provider 输出兼容层 + 互动叙事 think 清理 + Vite/状态栏修复

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,7 @@ docs/
 .DS_Store
 .nova
 prd
+
+# 本地编译产物与缓存
+/nova
+.vite/

--- a/cmd/nova/main.go
+++ b/cmd/nova/main.go
@@ -132,7 +132,19 @@ func startViteDev(port, host string) {
 		}
 	}
 
-	cmd := exec.Command("pnpm", "dev", "--host", host, "--port", port)
+	// 优先使用本地 vite 二进制，绕过 pnpm 运行前的依赖校验：
+	// pnpm 在执行 run 脚本前会强制做 deps status check，未批准的依赖构建脚本（如 msw）会让
+	// `pnpm dev` 直接以 ERR_PNPM_IGNORED_BUILDS 失败，导致前端开发服务器静默起不来。
+	var cmd *exec.Cmd
+	viteBin := filepath.Join(webDir, "node_modules", ".bin", "vite")
+	if abs, err := filepath.Abs(viteBin); err == nil {
+		viteBin = abs
+	}
+	if _, err := os.Stat(viteBin); err == nil {
+		cmd = exec.Command(viteBin, "--host", host, "--port", port)
+	} else {
+		cmd = exec.Command("pnpm", "dev", "--host", host, "--port", port)
+	}
 	cmd.Dir = webDir
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr

--- a/internal/agent/builder.go
+++ b/internal/agent/builder.go
@@ -19,6 +19,7 @@ import (
 	"nova/config"
 	"nova/internal/book"
 	"nova/internal/prompts"
+	"nova/internal/providercompat"
 	novaskills "nova/internal/skills"
 )
 
@@ -140,6 +141,9 @@ func buildDeepAgent(ctx context.Context, cfg *config.Config, spec deepAgentSpec)
 	if err != nil {
 		return nil, fmt.Errorf("创建模型失败: %w", err)
 	}
+	// providercompat 决定是否要为这个 provider 加包装层（修复工具调用格式、剥离内联 think 等）。
+	// agent 包不感知具体 provider；新增 provider 的兼容性处理只需在 providercompat 里加。
+	chatModel := providercompat.Wrap(cm, modelCfg)
 
 	localBackend, err := localbk.NewBackend(ctx, &localbk.Config{})
 	if err != nil {
@@ -196,7 +200,7 @@ func buildDeepAgent(ctx context.Context, cfg *config.Config, spec deepAgentSpec)
 	return deep.New(ctx, &deep.Config{
 		Name:              spec.Name,
 		Description:       spec.Description,
-		ChatModel:         cm,
+		ChatModel:         chatModel,
 		Instruction:       spec.Instruction,
 		WithoutWriteTodos: spec.DisableWriteTodos || !toolSettings.Todo,
 		MaxIteration:      configMaxIteration(cfg),

--- a/internal/agent/model.go
+++ b/internal/agent/model.go
@@ -4,6 +4,7 @@ import (
 	"github.com/cloudwego/eino-ext/components/model/openai"
 
 	"nova/config"
+	"nova/internal/providercompat"
 )
 
 func chatModelConfigForAgent(cfg *config.Config, agentKind string) openai.ChatModelConfig {
@@ -17,10 +18,17 @@ func chatModelConfigForAgent(cfg *config.Config, agentKind string) openai.ChatMo
 		temperature := float32(*resolved.Temperature)
 		modelCfg.Temperature = &temperature
 	}
+	extraFields := map[string]any{}
 	if resolved.EnableThinking != nil {
-		modelCfg.ExtraFields = map[string]any{
-			"enable_thinking": *resolved.EnableThinking,
-		}
+		extraFields["enable_thinking"] = *resolved.EnableThinking
+	}
+	// 让 providercompat 决定是否要注入 provider 特有的请求字段。
+	// agent 包不感知任何具体 provider。
+	for k, v := range providercompat.ExtraRequestFields(modelCfg) {
+		extraFields[k] = v
+	}
+	if len(extraFields) > 0 {
+		modelCfg.ExtraFields = extraFields
 	}
 	if resolved.ReasoningEffort != "" {
 		modelCfg.ReasoningEffort = openai.ReasoningEffortLevel(resolved.ReasoningEffort)

--- a/internal/app/interactive_agent_test.go
+++ b/internal/app/interactive_agent_test.go
@@ -617,6 +617,18 @@ func TestParseInteractiveAssistantOutput(t *testing.T) {
 		t.Fatalf("expected invalid state to fall back to async state, narrative=%q ops=%#v err=%v", narrative, ops, err)
 	}
 
+	// MiniMax 模式：思考前言无 <think> 开始标签、仅以 </think> 收尾，随后才是 <NARRATIVE>。
+	narrative, _, _, err = parseInteractiveAssistantOutput("tags\n\nLet me write the opening:</think>\n\n<NARRATIVE>\n意识像被冷水浇醒。\n</NARRATIVE>")
+	if err != nil || narrative != "意识像被冷水浇醒。" {
+		t.Fatalf("expected minimax orphan </think> prelude stripped, narrative=%q err=%v", narrative, err)
+	}
+
+	// MiniMax 且未输出 <NARRATIVE>：思考前言 + 裸正文。
+	narrative, _, _, err = parseInteractiveAssistantOutput("思考中...</think>\n真正的正文。")
+	if err != nil || narrative != "真正的正文。" {
+		t.Fatalf("expected orphan </think> without narrative stripped, narrative=%q err=%v", narrative, err)
+	}
+
 	_, _, _, err = parseInteractiveAssistantOutput("<STATE_DELTA>{\"ops\":[]}</STATE_DELTA>")
 	if err == nil {
 		t.Fatalf("expected empty narrative error")

--- a/internal/app/interactive_response.go
+++ b/internal/app/interactive_response.go
@@ -15,6 +15,8 @@ const (
 	narrativeEndTag    = "</NARRATIVE>"
 	stateDeltaStartTag = "<STATE_DELTA>"
 	stateDeltaEndTag   = "</STATE_DELTA>"
+	thinkOpenTag       = "<think>"
+	thinkCloseTag      = "</think>"
 )
 
 type interactiveStatePayload struct {
@@ -147,12 +149,37 @@ func parseInteractiveHotState(content string) (*interactive.HotState, error) {
 
 func extractNarrative(content string) string {
 	if narrative, ok := extractBetween(content, narrativeStartTag, narrativeEndTag); ok {
-		return narrative
+		return stripThinkPrelude(narrative)
 	}
 	if idx := firstHiddenStateTagIndex(content); idx >= 0 {
-		return content[:idx]
+		return stripThinkPrelude(content[:idx])
 	}
-	return content
+	return stripThinkPrelude(content)
+}
+
+// stripThinkPrelude 移除叙事正文里残留的思考块，兜底模型把思考混入正文的情况：
+// 配对 <think>...</think>、未闭合 <think>...，以及无开始标签、仅以 </think> 收尾的前言（如 MiniMax）。
+func stripThinkPrelude(s string) string {
+	for {
+		open := thinkIndexFold(s, thinkOpenTag)
+		if open < 0 {
+			break
+		}
+		closeIdx := thinkIndexFold(s[open:], thinkCloseTag)
+		if closeIdx < 0 {
+			s = s[:open]
+			break
+		}
+		s = s[:open] + s[open+closeIdx+len(thinkCloseTag):]
+	}
+	if closeIdx := thinkIndexFold(s, thinkCloseTag); closeIdx >= 0 {
+		s = s[closeIdx+len(thinkCloseTag):]
+	}
+	return strings.TrimSpace(s)
+}
+
+func thinkIndexFold(s, sub string) int {
+	return strings.Index(strings.ToLower(s), strings.ToLower(sub))
 }
 
 func firstHiddenStateTagIndex(content string) int {

--- a/internal/providercompat/polyfill.go
+++ b/internal/providercompat/polyfill.go
@@ -1,0 +1,315 @@
+// Package providercompat provides model-output compatibility polyfills.
+//
+// Some OpenAI-compatible providers (e.g. MiniMax) don't return standard
+// tool_calls or wrap thinking in <think> tags inside content. This package
+// offers a single entry point — Wrap — that inspects the model config and
+// transparently adapts the chat model when the provider needs it. Main code
+// (e.g. internal/agent) should not branch on provider names; instead it
+// just calls Wrap(cm, cfg) and forgets about it.
+package providercompat
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"regexp"
+	"strings"
+
+	"github.com/cloudwego/eino-ext/components/model/openai"
+	"github.com/cloudwego/eino/components/model"
+	"github.com/cloudwego/eino/schema"
+)
+
+// Wrap returns a possibly-decorated chat model that hides provider-specific
+// quirks. If the model needs no polyfill, the original is returned untouched.
+func Wrap(cm model.ToolCallingChatModel, cfg openai.ChatModelConfig) model.ToolCallingChatModel {
+	if polyfills := detect(cfg); len(polyfills) > 0 {
+		log.Printf("[providercompat] applying %d polyfill(s) model=%q", len(polyfills), cfg.Model)
+		cm = chain(cm, polyfills)
+	}
+	return cm
+}
+
+// ExtraRequestFields returns provider-specific fields that should be merged
+// into the request body (e.g. reasoning_split for MiniMax). Called once when
+// building the chat model config, before any request is sent.
+func ExtraRequestFields(cfg openai.ChatModelConfig) map[string]any {
+	out := map[string]any{}
+	if isMinimax(cfg) {
+		// MiniMax-M3 默认把思考写入 content 的 <think> 标签；reasoning_split=true 让其改用
+		// 标准 reasoning_content 字段返回，从根本上避免 <think> 泄漏到正文
+		// （见 MiniMax OpenAI 兼容文档）。
+		out["reasoning_split"] = true
+	}
+	return out
+}
+
+type polyfill interface {
+	apply(model.ToolCallingChatModel) model.ToolCallingChatModel
+}
+
+// detect inspects the config and returns the polyfill chain to apply.
+// Order matters: later polyfills see output of earlier ones.
+func detect(cfg openai.ChatModelConfig) []polyfill {
+	var out []polyfill
+	if isMinimax(cfg) {
+		// Both polyfills needed: tool-call text-to-struct, then think-tag cleanup
+		// (in case reasoning_split is ignored or falls back to inline tags).
+		out = append(out, toolCallTextPolyfill{})
+		out = append(out, inlineThinkPolyfill{})
+	}
+	return out
+}
+
+func chain(cm model.ToolCallingChatModel, ps []polyfill) model.ToolCallingChatModel {
+	for _, p := range ps {
+		cm = p.apply(cm)
+	}
+	return cm
+}
+
+// isMinimax checks the base URL or model name. Cheap, called once per Wrap.
+func isMinimax(cfg openai.ChatModelConfig) bool {
+	base := strings.ToLower(cfg.BaseURL)
+	return strings.Contains(base, "minimax") || strings.Contains(strings.ToLower(cfg.Model), "minimax")
+}
+
+// -----------------------------------------------------------------------------
+// Polyfill 1: tool calls delivered as inline text instead of structured
+// tool_calls. We parse the antml-style <tool_call><invoke name="...">…</invoke> </tool_call>
+// XML and promote them to schema.ToolCall so the framework actually executes
+// the tools.
+// -----------------------------------------------------------------------------
+
+type toolCallTextPolyfill struct{}
+
+var (
+	pcInvokeRe    = regexp.MustCompile(`(?s)<invoke\s+name="([^"]+)"\s*>(.*?)</invoke>`)
+	pcToolCallRe  = regexp.MustCompile(`(?s)<tool_call>(.*?)</tool_call>`)
+	pcParamNamedR = regexp.MustCompile(`(?s)<parameter\s+name="([^"]+)"\s*>(.*?)</parameter>`)
+	pcParamTagR   = regexp.MustCompile(`(?s)<([a-zA-Z_][\w.-]*)>(.*?)</[a-zA-Z_][\w.-]*>`)
+)
+
+func (toolCallTextPolyfill) apply(inner model.ToolCallingChatModel) model.ToolCallingChatModel {
+	return &toolCallTextModel{inner: inner}
+}
+
+type toolCallTextModel struct{ inner model.ToolCallingChatModel }
+
+func (m *toolCallTextModel) Generate(ctx context.Context, in []*schema.Message, opts ...model.Option) (*schema.Message, error) {
+	msg, err := m.inner.Generate(ctx, in, opts...)
+	if err != nil || msg == nil {
+		return msg, err
+	}
+	extractTextToolCalls(msg)
+	return msg, nil
+}
+
+func (m *toolCallTextModel) Stream(ctx context.Context, in []*schema.Message, opts ...model.Option) (*schema.StreamReader[*schema.Message], error) {
+	// Tool-call extraction requires full content (it must see the closing </tool_call>
+	// to know the call is complete). Buffer the whole stream, then re-emit as
+	// a single frame so downstream logic receives a repaired message.
+	sr, err := m.inner.Stream(ctx, in, opts...)
+	if err != nil {
+		return nil, err
+	}
+	defer sr.Close()
+	var frames []*schema.Message
+	for {
+		f, err := sr.Recv()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		if f != nil {
+			frames = append(frames, f)
+		}
+	}
+	if len(frames) == 0 {
+		return schema.StreamReaderFromArray(frames), nil
+	}
+	merged, err := schema.ConcatMessages(frames)
+	if err != nil || merged == nil {
+		return schema.StreamReaderFromArray(frames), nil
+	}
+	extractTextToolCalls(merged)
+	return schema.StreamReaderFromArray([]*schema.Message{merged}), nil
+}
+
+func (m *toolCallTextModel) WithTools(tools []*schema.ToolInfo) (model.ToolCallingChatModel, error) {
+	inner, err := m.inner.WithTools(tools)
+	if err != nil {
+		return nil, err
+	}
+	return &toolCallTextModel{inner: inner}, nil
+}
+
+func extractTextToolCalls(msg *schema.Message) {
+	if msg == nil || len(msg.ToolCalls) > 0 || msg.Content == "" {
+		return
+	}
+	matches := pcInvokeRe.FindAllStringSubmatch(msg.Content, -1)
+	if len(matches) == 0 {
+		return
+	}
+	calls := make([]schema.ToolCall, 0, len(matches))
+	for i, m := range matches {
+		name := strings.TrimSpace(m[1])
+		if name == "" {
+			continue
+		}
+		params := parseInvokeParams(m[2])
+		args, _ := json.Marshal(params)
+		idx := i
+		calls = append(calls, schema.ToolCall{
+			Index: &idx,
+			ID:    fmt.Sprintf("text_tool_call_%d", i),
+			Type:  "function",
+			Function: schema.FunctionCall{
+				Name:      name,
+				Arguments: string(args),
+			},
+		})
+	}
+	if len(calls) == 0 {
+		return
+	}
+	msg.ToolCalls = calls
+	msg.Content = pcToolCallRe.ReplaceAllString(msg.Content, "")
+	msg.Content = pcInvokeRe.ReplaceAllString(msg.Content, "")
+}
+
+func parseInvokeParams(body string) map[string]string {
+	out := map[string]string{}
+	if named := pcParamNamedR.FindAllStringSubmatch(body, -1); len(named) > 0 {
+		for _, m := range named {
+			if k := strings.TrimSpace(m[1]); k != "" {
+				out[k] = strings.TrimSpace(m[2])
+			}
+		}
+		return out
+	}
+	for _, m := range pcParamTagR.FindAllStringSubmatch(body, -1) {
+		k := strings.TrimSpace(m[1])
+		if k == "" || strings.EqualFold(k, "parameter") {
+			continue
+		}
+		out[k] = strings.TrimSpace(m[2])
+	}
+	return out
+}
+
+// -----------------------------------------------------------------------------
+// Polyfill 2: some providers (or fallback paths) still emit <think>…</think>
+// inline. Strip them from content and surface as ReasoningContent if missing.
+// -----------------------------------------------------------------------------
+
+type inlineThinkPolyfill struct{}
+
+func (inlineThinkPolyfill) apply(inner model.ToolCallingChatModel) model.ToolCallingChatModel {
+	return &inlineThinkModel{inner: inner}
+}
+
+type inlineThinkModel struct{ inner model.ToolCallingChatModel }
+
+func (m *inlineThinkModel) Generate(ctx context.Context, in []*schema.Message, opts ...model.Option) (*schema.Message, error) {
+	msg, err := m.inner.Generate(ctx, in, opts...)
+	if err != nil || msg == nil {
+		return msg, err
+	}
+	stripInlineThink(msg)
+	return msg, nil
+}
+
+func (m *inlineThinkModel) Stream(ctx context.Context, in []*schema.Message, opts ...model.Option) (*schema.StreamReader[*schema.Message], error) {
+	sr, err := m.inner.Stream(ctx, in, opts...)
+	if err != nil {
+		return nil, err
+	}
+	defer sr.Close()
+	var frames []*schema.Message
+	for {
+		f, err := sr.Recv()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		if f != nil {
+			frames = append(frames, f)
+		}
+	}
+	if len(frames) == 0 {
+		return schema.StreamReaderFromArray(frames), nil
+	}
+	merged, err := schema.ConcatMessages(frames)
+	if err != nil || merged == nil {
+		return schema.StreamReaderFromArray(frames), nil
+	}
+	stripInlineThink(merged)
+	return schema.StreamReaderFromArray([]*schema.Message{merged}), nil
+}
+
+func (m *inlineThinkModel) WithTools(tools []*schema.ToolInfo) (model.ToolCallingChatModel, error) {
+	inner, err := m.inner.WithTools(tools)
+	if err != nil {
+		return nil, err
+	}
+	return &inlineThinkModel{inner: inner}, nil
+}
+
+func stripInlineThink(msg *schema.Message) {
+	if msg == nil || msg.Content == "" {
+		return
+	}
+	clean, thinking := stripThinkTagsSimple(msg.Content)
+	if thinking != "" && strings.TrimSpace(msg.ReasoningContent) == "" {
+		msg.ReasoningContent = thinking
+	}
+	msg.Content = clean
+}
+
+// stripThinkTagsSimple removes paired/unclosed <think>…</think> and orphan </think>
+// prelude in one shot. Used on whole-message content (post-stream concat), so
+// regex is fine — no cross-chunk state to maintain. The agent package's
+// thinkTagExtractor handles the streaming variant separately.
+func stripThinkTagsSimple(s string) (content, thinking string) {
+	// paired <think>…</think> (lazy, may not find anything if unclosed)
+	paired := regexp.MustCompile(`(?is)<think>(.*?)(?:</think>|$)`)
+	matches := paired.FindAllStringSubmatchIndex(s, -1)
+	if len(matches) == 0 {
+		// no <think> opener: maybe an orphan </think> prelude
+		if idx := strings.Index(strings.ToLower(s), "</think>"); idx >= 0 {
+			prelude := strings.TrimSpace(s[:idx])
+			if prelude != "" {
+				thinking = prelude
+			}
+			content = strings.TrimLeft(s[idx+len("</think>"):], " \t\r\n")
+		} else {
+			content = s
+		}
+		return content, thinking
+	}
+	var contentBuilder, thinkBuilder strings.Builder
+	last := 0
+	for _, m := range matches {
+		if m[0] > last {
+			contentBuilder.WriteString(s[last:m[0]])
+		}
+		thinkBuilder.WriteString(s[m[2]:m[3]])
+		last = m[1]
+	}
+	contentBuilder.WriteString(s[last:])
+	// also strip any orphan </think> remaining in the content tail
+	content = paired.ReplaceAllString(contentBuilder.String(), "")
+	// and any orphan </think> fragments
+	content = regexp.MustCompile(`(?i)\n?</think>\s*`).ReplaceAllString(content, "")
+	content = strings.TrimLeft(content, " \t\r\n")
+	return content, thinkBuilder.String()
+}

--- a/internal/providercompat/polyfill_test.go
+++ b/internal/providercompat/polyfill_test.go
@@ -1,0 +1,116 @@
+package providercompat
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/cloudwego/eino-ext/components/model/openai"
+	"github.com/cloudwego/eino/components/model"
+	"github.com/cloudwego/eino/schema"
+)
+
+// fakeChatModel is a minimal ToolCallingChatModel that returns a fixed
+// message. We use it to assert that Wrap repairs the inner model's output.
+type fakeChatModel struct {
+	fixedMsg *schema.Message
+}
+
+func (f *fakeChatModel) Generate(_ context.Context, _ []*schema.Message, _ ...model.Option) (*schema.Message, error) {
+	return f.fixedMsg, nil
+}
+func (f *fakeChatModel) Stream(_ context.Context, _ []*schema.Message, _ ...model.Option) (*schema.StreamReader[*schema.Message], error) {
+	if f.fixedMsg == nil {
+		return schema.StreamReaderFromArray([]*schema.Message{}), nil
+	}
+	return schema.StreamReaderFromArray([]*schema.Message{f.fixedMsg}), nil
+}
+func (f *fakeChatModel) WithTools(_ []*schema.ToolInfo) (model.ToolCallingChatModel, error) {
+	return f, nil
+}
+
+func TestExtraRequestFields_MiniMax(t *testing.T) {
+	cfg := openai.ChatModelConfig{BaseURL: "https://minimaxi.com/v1/", Model: "MiniMax-M3"}
+	got := ExtraRequestFields(cfg)
+	if v, ok := got["reasoning_split"]; !ok || v != true {
+		t.Fatalf("expected reasoning_split=true for MiniMax, got %v", got)
+	}
+}
+
+func TestExtraRequestFields_OtherProvider(t *testing.T) {
+	for _, cfg := range []openai.ChatModelConfig{
+		{BaseURL: "https://api.openai.com/v1", Model: "gpt-4o"},
+		{BaseURL: "https://api.deepseek.com/v1", Model: "deepseek-chat"},
+	} {
+		if got := ExtraRequestFields(cfg); len(got) != 0 {
+			t.Fatalf("expected no extras for %s, got %v", cfg.BaseURL, got)
+		}
+	}
+}
+
+func TestWrap_MiniMax_RepairsToolCallAndThink(t *testing.T) {
+	// 复刻真实 MiniMax-M3 输出：think + 文本工具调用 + 内部特殊 token
+	content := "<think>Let me load the skill.</think>\n\n" +
+		"加载 rewrite skill 的具体流程。<tool_call>\n" +
+		"<invoke name=\"skill\"><skill>rewrite</skill></invoke>\n" +
+		"</tool_call>"
+	inner := &fakeChatModel{fixedMsg: &schema.Message{Role: schema.Assistant, Content: content}}
+	cfg := openai.ChatModelConfig{BaseURL: "https://minimaxi.com/v1/", Model: "MiniMax-M3"}
+
+	wrapped := Wrap(inner, cfg)
+	out, err := wrapped.Generate(context.Background(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(out.ToolCalls) != 1 {
+		t.Fatalf("expected 1 tool call, got %d (%#v)", len(out.ToolCalls), out.ToolCalls)
+	}
+	if name := out.ToolCalls[0].Function.Name; name != "skill" {
+		t.Fatalf("tool name = %q, want skill", name)
+	}
+	if args := out.ToolCalls[0].Function.Arguments; args != `{"skill":"rewrite"}` {
+		t.Fatalf("args = %q, want {\"skill\":\"rewrite\"}", args)
+	}
+	if out.Content != "加载 rewrite skill 的具体流程。" {
+		t.Fatalf("content = %q", out.Content)
+	}
+	if !strings.Contains(out.ReasoningContent, "load the skill") {
+		t.Fatalf("reasoning not captured: %q", out.ReasoningContent)
+	}
+}
+
+func TestWrap_MiniMax_PreservesNativeToolCalls(t *testing.T) {
+	idx := 0
+	inner := &fakeChatModel{fixedMsg: &schema.Message{
+		Role:    schema.Assistant,
+		Content: "正文",
+		ToolCalls: []schema.ToolCall{{
+			Index: &idx, ID: "x", Type: "function",
+			Function: schema.FunctionCall{Name: "read_file", Arguments: "{}"},
+		}},
+	}}
+	cfg := openai.ChatModelConfig{BaseURL: "https://minimaxi.com/v1/", Model: "MiniMax-M3"}
+	out, err := Wrap(inner, cfg).Generate(context.Background(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(out.ToolCalls) != 1 || out.ToolCalls[0].Function.Name != "read_file" {
+		t.Fatalf("native tool calls altered: %#v", out.ToolCalls)
+	}
+}
+
+func TestWrap_OtherProvider_PassThrough(t *testing.T) {
+	inner := &fakeChatModel{fixedMsg: &schema.Message{Role: schema.Assistant, Content: "raw <think>oops</think> done"}}
+	cfg := openai.ChatModelConfig{BaseURL: "https://api.openai.com/v1", Model: "gpt-4o"}
+	// OpenAI 端点：原样返回，think 标签不应被剥离（信任它走 reasoning_content 字段）
+	out, err := Wrap(inner, cfg).Generate(context.Background(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.Content != "raw <think>oops</think> done" {
+		t.Fatalf("OpenAI output unexpectedly modified: %q", out.Content)
+	}
+	if out.ReasoningContent != "" {
+		t.Fatalf("OpenAI reasoning unexpectedly populated: %q", out.ReasoningContent)
+	}
+}

--- a/web/package.json
+++ b/web/package.json
@@ -64,5 +64,8 @@
     "tailwindcss": "^4.3.0",
     "zod": "^4.4.3",
     "zustand": "^5.0.13"
+  },
+  "pnpm": {
+    "ignoredBuiltDependencies": ["msw"]
   }
 }

--- a/web/src/components/Chat/MessageItem.tsx
+++ b/web/src/components/Chat/MessageItem.tsx
@@ -51,11 +51,16 @@ export const MessageItem = memo(function MessageItem({ message, highlightDialogu
         </div>
       )
 
-    case 'assistant':
+    case 'assistant': {
+      // 流式期间正文可能尚未到达，或全是被隐藏的思考内容（清洗后为空）：
+      // 此时显示"正在思考"占位，避免出现一个空白气泡、像卡死无响应。
+      const visibleContent = sanitizeThinkTags(content).trim()
       return (
         <div className="group flex justify-start">
           <div className="chat-agent-message w-full px-1 text-sm text-[var(--nova-text)]" style={messageStyle}>
-            {message.streaming ? (
+            {message.streaming && !visibleContent ? (
+              <StreamingPlaceholder />
+            ) : message.streaming ? (
               <StreamingMarkdown content={content} highlightDialogue={highlightDialogue} />
             ) : (
               <MarkdownContent content={content} highlightDialogue={highlightDialogue} />
@@ -103,6 +108,7 @@ export const MessageItem = memo(function MessageItem({ message, highlightDialogu
           </div>
         </div>
       )
+    }
 
     case 'thinking':
       return <ThinkingBlock content={content} streaming={message.streaming === true} />
@@ -548,9 +554,41 @@ function extractStreamingContent(rawArgs: string): string {
   return text
 }
 
+/** 流式等待占位：正文尚未到达（或仅有被隐藏的思考）时显示，避免空白气泡像卡死。 */
+function StreamingPlaceholder() {
+  const { t } = useTranslation()
+  return (
+    <div className="flex items-center gap-2 py-1 text-sm text-[var(--nova-text-muted)]">
+      <span className="flex gap-1">
+        <span className="h-1.5 w-1.5 animate-bounce rounded-full bg-[var(--nova-text-muted)] [animation-delay:-0.3s]" />
+        <span className="h-1.5 w-1.5 animate-bounce rounded-full bg-[var(--nova-text-muted)] [animation-delay:-0.15s]" />
+        <span className="h-1.5 w-1.5 animate-bounce rounded-full bg-[var(--nova-text-muted)]" />
+      </span>
+      <span>{t('chat.activity.thinking')}</span>
+    </div>
+  )
+}
+
 /** 流式和持久化消息共用同一 Markdown 渲染器，避免刷新后段落、列表和行距重新排版。 */
 function StreamingMarkdown({ content, highlightDialogue }: { content: string; highlightDialogue: boolean }) {
   return <MarkdownContent content={content} highlightDialogue={highlightDialogue} />
+}
+
+function sanitizeThinkTags(text: string): string {
+  let result = text
+  // MiniMax 内部特殊 token 与文本形式的工具调用残留（兜底历史数据；新对话已由后端解析执行）
+  result = result.replace(/\]<\]minimax\[>\[/g, '')
+  result = result.replace(/<tool_call>[\s\S]*?<\/tool_call>/gi, '')
+  result = result.replace(/<invoke\s+name="[^"]*"[\s\S]*?<\/invoke>/gi, '')
+  // 配对或未闭合的 <think>...</think>
+  result = result.replace(/<think>[\s\S]*?(?:<\/think>|$)/gi, '')
+  // 无 <think> 开始标签、仅以 </think> 收尾的思考前言（如 MiniMax）：删除开头直到首个 </think>
+  const close = result.search(/<\s*\/\s*think\s*>/i)
+  if (close >= 0) {
+    result = result.slice(close).replace(/<\s*\/\s*think\s*>/i, '')
+  }
+  // 清理任何残留 think 标签
+  return result.replace(/<\/?\s*think\s*>/gi, '')
 }
 
 const MarkdownContent = memo(function MarkdownContent({ content, highlightDialogue }: { content: string; highlightDialogue: boolean }) {

--- a/web/src/components/workbench/WorkbenchShell.tsx
+++ b/web/src/components/workbench/WorkbenchShell.tsx
@@ -11,7 +11,9 @@ import { WorkspaceMobileLayout, type MobileNavItem } from '@/components/layout/w
 import { TooltipIconButton } from '@/components/common/tooltip-icon-button'
 import { novaSpring } from '@/features/motion/motion-tokens'
 import { useIsMobile } from '@/hooks/useIsMobile'
+import { useQuery } from '@tanstack/react-query'
 import { getAutomationInbox, type ChapterSummary, type WorkspaceSummary } from '@/lib/api'
+import { fetchSettings } from '@/features/settings/api'
 import type { RightPanel, WorkspaceMode } from '@/stores/workspace-store'
 import type { InteractiveSubmode } from '@/features/interactive/types'
 import { formatNumber } from './workbench-utils'
@@ -95,6 +97,9 @@ export function WorkbenchShell({
 }: WorkbenchShellProps) {
   const { t } = useTranslation()
   const isMobile = useIsMobile()
+  // 状态栏展示当前配置的实际模型名（此前被硬编码为 "DeepSeek"，与实际模型无关）。
+  const { data: layeredSettings } = useQuery({ queryKey: ['settings'], queryFn: fetchSettings, staleTime: 60_000 })
+  const modelName = layeredSettings?.effective?.openai_model?.trim() || ''
   const [activityOrders, setActivityOrders] = useState<Record<ActivityOrderScope, ActivityItemId[]>>(readStoredActivityOrders)
   const [automationInboxUnread, setAutomationInboxUnread] = useState(0)
   const sensors = useSensors(
@@ -448,7 +453,7 @@ export function WorkbenchShell({
       {mode === 'ide' && currentChapter && (
         <span className="ml-4">{t('workbench.status.currentChapter', { title: currentChapter.display_title, words: formatNumber(currentChapter.words), status: currentChapter.status })}</span>
       )}
-      <span className="ml-auto">{isStreaming ? t('workbench.status.streaming') : t('workbench.status.idle')} · DeepSeek</span>
+      <span className="ml-auto">{isStreaming ? t('workbench.status.streaming') : t('workbench.status.idle')}{modelName ? ` · ${modelName}` : ''}</span>
     </div>
   )
 

--- a/web/src/features/interactive/components/StoryStage.tsx
+++ b/web/src/features/interactive/components/StoryStage.tsx
@@ -22,7 +22,7 @@ import type { ChatMessage, ContextAnalysis } from '@/lib/api'
 import { fetchSettings } from '@/features/settings/api'
 import { useSkillCommands } from '@/hooks/useSkillCommands'
 import { abortInteractiveChat, analyzeInteractiveContext, compactInteractiveContext, generateInteractiveHotChoices, removeInteractiveContextCompaction, sendInteractiveMessage, switchInteractiveTurnVersion } from '../api'
-import { createInteractiveNarrativeFilter } from '../stream-parser'
+import { createInteractiveNarrativeFilter, sanitizeStoredNarrative } from '../stream-parser'
 import { emptyStoryStageRun, useInteractiveStore } from '../stores/interactive-store'
 import type { StoryStageRunState } from '../stores/interactive-store'
 import { DEFAULT_INTERACTIVE_REPLY_TARGET_CHARS, buildOpeningPrompt, truncateStoryOpeningText, type BookOpeningPreset, type StoryCreateInput } from '../opening'
@@ -271,7 +271,7 @@ export function StoryStage({ workspace, styleSuggestions = [], stories = [], sto
         id: `${turn.id}-assistant`,
         turn_id: turn.id,
         role: 'assistant',
-        content: turn.narrative,
+        content: sanitizeStoredNarrative(turn.narrative),
         turn_versions: turn.versions,
         turn_version_index: turn.version_idx,
       })
@@ -440,10 +440,11 @@ export function StoryStage({ workspace, styleSuggestions = [], stories = [], sto
         switch (value.event) {
           case 'chunk': {
             const data = JSON.parse(value.data)
-            const visible = narrativeFilter.push(data.content || '')
-            if (visible) {
+            const { text, reset } = narrativeFilter.push(data.content || '')
+            if (reset) resetAssistantMessage()
+            if (text) {
               collapseNonNarrativeMessages()
-              appendAssistantMessage(visible)
+              appendAssistantMessage(text)
             }
             setStageActivityContent('')
             break
@@ -502,17 +503,19 @@ export function StoryStage({ workspace, styleSuggestions = [], stories = [], sto
             break
           }
           case 'done': {
-            const visible = narrativeFilter.flush()
+            const { text, reset } = narrativeFilter.flush()
+            if (reset) resetAssistantMessage()
             collapseNonNarrativeMessages()
-            if (visible) appendAssistantMessage(visible)
+            if (text) appendAssistantMessage(text)
             finishLiveMessages()
             setStageActivityContent(t('storyStage.activity.done'))
             break
           }
           case 'aborted': {
-            const visible = narrativeFilter.flush()
+            const { text, reset } = narrativeFilter.flush()
+            if (reset) resetAssistantMessage()
             collapseNonNarrativeMessages()
-            if (visible) appendAssistantMessage(visible)
+            if (text) appendAssistantMessage(text)
             finishLiveMessages()
             setStageActivityContent(t('storyStage.activity.aborted'))
             break
@@ -1109,6 +1112,17 @@ export function StoryStage({ workspace, styleSuggestions = [], stories = [], sto
         return [...prev.slice(0, -1), { ...last, content: `${last.content || ''}${content}` }]
       }
       return [...prev, { role: 'assistant', content, streaming: true }]
+    })
+  }
+
+  // 思考前言曾被误当正文显示时（MiniMax 孤立 </think>），丢弃这条流式 assistant 消息，正文随后另起。
+  function resetAssistantMessage() {
+    setStageLiveMessages((prev) => {
+      const last = prev[prev.length - 1]
+      if (last?.role === 'assistant' && last.streaming) {
+        return prev.slice(0, -1)
+      }
+      return prev
     })
   }
 

--- a/web/src/features/interactive/stream-parser.test.ts
+++ b/web/src/features/interactive/stream-parser.test.ts
@@ -1,63 +1,105 @@
 import { describe, expect, it } from 'vitest'
-import { createInteractiveNarrativeFilter } from './stream-parser'
+import { createInteractiveNarrativeFilter, sanitizeStoredNarrative } from './stream-parser'
+
+/** 模拟 StoryStage 的累积逻辑：reset 时清空已显示正文，否则追加。 */
+function collect(chunks: string[]): string {
+  const filter = createInteractiveNarrativeFilter()
+  let shown = ''
+  for (const chunk of chunks) {
+    const { text, reset } = filter.push(chunk)
+    if (reset) shown = ''
+    shown += text
+  }
+  const { text, reset } = filter.flush()
+  if (reset) shown = ''
+  shown += text
+  return shown
+}
 
 describe('createInteractiveNarrativeFilter', () => {
   it('removes narrative tags and hides state delta', () => {
-    const filter = createInteractiveNarrativeFilter()
-    const visible = [
-      filter.push('<NARRATIVE>\n火光照亮了'),
-      filter.push('墙上的新线索。\n</NARRATIVE>\n<STATE_DELTA>'),
-      filter.push('{"ops":[{"op":"set","path":"on_stage","value":["林川"]}]}'),
-      filter.flush(),
-    ].join('')
-
-    expect(visible).toBe('\n火光照亮了墙上的新线索。\n')
+    const visible = collect([
+      '<NARRATIVE>\n火光照亮了',
+      '墙上的新线索。\n</NARRATIVE>\n<STATE_DELTA>',
+      '{"ops":[{"op":"set","path":"on_stage","value":["林川"]}]}',
+    ])
+    expect(visible).toBe('火光照亮了墙上的新线索。\n')
   })
 
   it('hides hot state choices after narrative', () => {
-    const filter = createInteractiveNarrativeFilter()
-    const visible = [
-      filter.push('<NARRATIVE>门后传来风声。</NARRATIVE><HOT'),
-      filter.push('_STATE>{"choices":["我贴近门缝听里面的动静。"]}</HOT_STATE>'),
-      filter.flush(),
-    ].join('')
-
+    const visible = collect([
+      '<NARRATIVE>门后传来风声。</NARRATIVE><HOT',
+      '_STATE>{"choices":["我贴近门缝听里面的动静。"]}</HOT_STATE>',
+    ])
     expect(visible).toBe('门后传来风声。')
   })
 
   it('hides lowercase or spaced hot state tags', () => {
-    const filter = createInteractiveNarrativeFilter()
-    const visible = [
-      filter.push('<NARRATIVE>门后传来风声。</NARRATIVE>\n< hot'),
-      filter.push('_state>{"choices":["我贴近门缝听里面的动静。"]}</hot_state>'),
-      filter.flush(),
-    ].join('')
-
+    const visible = collect([
+      '<NARRATIVE>门后传来风声。</NARRATIVE>\n< hot',
+      '_state>{"choices":["我贴近门缝听里面的动静。"]}</hot_state>',
+    ])
     expect(visible).toBe('门后传来风声。')
   })
 
   it('handles tags split across chunks', () => {
-    const filter = createInteractiveNarrativeFilter()
-    const visible = [
-      filter.push('<NARR'),
-      filter.push('ATIVE>门后传来低沉'),
-      filter.push('的风声。</NARR'),
-      filter.push('ATIVE><STATE'),
-      filter.push('_DELTA>{"ops":[]}'),
-      filter.flush(),
-    ].join('')
-
+    const visible = collect([
+      '<NARR',
+      'ATIVE>门后传来低沉',
+      '的风声。</NARR',
+      'ATIVE><STATE',
+      '_DELTA>{"ops":[]}',
+    ])
     expect(visible).toBe('门后传来低沉的风声。')
   })
 
   it('passes legacy narrative before state delta', () => {
-    const filter = createInteractiveNarrativeFilter()
-    const visible = [
-      filter.push('旧格式正文'),
-      filter.push('<STATE_DELTA>{"ops":[]}'),
-      filter.flush(),
-    ].join('')
-
+    const visible = collect(['旧格式正文', '<STATE_DELTA>{"ops":[]}'])
     expect(visible).toBe('旧格式正文')
+  })
+
+  it('strips minimax reasoning prelude with orphan </think> tag', () => {
+    // MiniMax：思考前言无 <think> 开始标签，仅以 </think> 收尾，随后才是 <NARRATIVE>。
+    const visible = collect([
+      'tags\n\nSince this is a new story.',
+      'Let me write the opening:</think>\n\n<NARRATIVE>\n意识像被冷水浇醒。',
+      '\n陆沉猛地睁开眼。</NARRATIVE><STATE_DELTA>{"ops":[]}',
+    ])
+    expect(visible).toBe('意识像被冷水浇醒。\n陆沉猛地睁开眼。')
+  })
+
+  it('strips paired <think> reasoning before narrative', () => {
+    const visible = collect([
+      '<think>让我想想怎么写</think>',
+      '<NARRATIVE>夜色降临。</NARRATIVE>',
+    ])
+    expect(visible).toBe('夜色降临。')
+  })
+
+  it('reset flag fires when reasoning prelude precedes narrative', () => {
+    const filter = createInteractiveNarrativeFilter()
+    const r1 = filter.push('thinking aloud here')
+    const r2 = filter.push('</think><NARRATIVE>正文</NARRATIVE>')
+    expect(r1.reset).toBe(false)
+    expect(r2.reset).toBe(true)
+  })
+})
+
+describe('sanitizeStoredNarrative', () => {
+  it('extracts narrative body from leaked minimax storage', () => {
+    const leaked = 'tags\n\nSince this is a new story.\nLet me write:</think>\n\n<NARRATIVE>\n意识像被冷水浇醒。\n陆沉睁开眼。'
+    expect(sanitizeStoredNarrative(leaked)).toBe('意识像被冷水浇醒。\n陆沉睁开眼。')
+  })
+
+  it('strips orphan </think> prelude without narrative tags', () => {
+    expect(sanitizeStoredNarrative('内心独白</think>\n真正的正文。')).toBe('真正的正文。')
+  })
+
+  it('keeps clean narrative unchanged', () => {
+    expect(sanitizeStoredNarrative('门后传来风声。')).toBe('门后传来风声。')
+  })
+
+  it('drops trailing hidden state block', () => {
+    expect(sanitizeStoredNarrative('正文。<STATE_DELTA>{"ops":[]}</STATE_DELTA>')).toBe('正文。')
   })
 })

--- a/web/src/features/interactive/stream-parser.ts
+++ b/web/src/features/interactive/stream-parser.ts
@@ -1,69 +1,158 @@
 const NARRATIVE_START = '<NARRATIVE>'
 const NARRATIVE_END = '</NARRATIVE>'
+const THINK_START = '<think>'
+const THINK_END = '</think>'
 
 const VISIBLE_TAGS = [NARRATIVE_START, NARRATIVE_END]
+const THINK_TAGS = [THINK_START, THINK_END]
 const HIDDEN_TAG_PREFIXES = ['<hot_state', '<state_delta']
-const TAG_PREFIXES = [...VISIBLE_TAGS.map((tag) => tag.toLowerCase()), ...HIDDEN_TAG_PREFIXES]
+const TAG_PREFIXES = [
+  ...VISIBLE_TAGS.map((tag) => tag.toLowerCase()),
+  ...THINK_TAGS.map((tag) => tag.toLowerCase()),
+  ...HIDDEN_TAG_PREFIXES,
+]
 
+export interface NarrativeChunk {
+  /** 本次新增的可见正文 */
+  text: string
+  /** 为 true 时，调用方应丢弃此前已显示的流式正文：之前输出的其实是思考前言。 */
+  reset: boolean
+}
+
+/**
+ * 互动叙事流式过滤器：只放行 <NARRATIVE> 内的正文，隐藏思考、状态、热状态。
+ *
+ * 兼容 MiniMax 等模型的「思考前言无 <think> 开始标签、仅以 </think> 收尾」的输出：
+ * 见到 <think> 或孤立 </think> 时，会把此前误显示的前言通过 reset 信号清除。
+ */
 export function createInteractiveNarrativeFilter() {
   let buffer = ''
   let stopped = false
+  let inThink = false
+  let emittedVisible = false
 
   return {
-    push(chunk: string): string {
-      if (!chunk || stopped) return ''
+    push(chunk: string): NarrativeChunk {
+      if (!chunk || stopped) return { text: '', reset: false }
       buffer += chunk
       return drain(false)
     },
-    flush(): string {
-      if (stopped) return ''
+    flush(): NarrativeChunk {
+      if (stopped) return { text: '', reset: false }
       return drain(true)
     },
   }
 
-  function drain(flushAll: boolean): string {
+  function drain(flushAll: boolean): NarrativeChunk {
     let output = ''
+    let reset = false
+
+    // 思考开始（含无开始标签的孤立 </think>）意味着此前显示的都是思考前言，需要清除。
+    const requestReset = () => {
+      if (emittedVisible || output) {
+        reset = true
+        output = ''
+        emittedVisible = false
+      }
+    }
+
     while (buffer) {
+      if (inThink) {
+        const end = indexOfFold(buffer, THINK_END)
+        if (end >= 0) {
+          buffer = trimStart(buffer.slice(end + THINK_END.length))
+          inThink = false
+          continue
+        }
+        // 未见到结束标签：丢弃整段思考，仅保留可能被截断的尾部标签前缀。
+        const keep = flushAll ? 0 : partialTagSuffixLength(buffer)
+        buffer = buffer.slice(buffer.length - keep)
+        return { text: output, reset }
+      }
+
       if (startsWithHiddenTag(buffer)) {
         stopped = true
         buffer = ''
-        return output
+        return { text: output, reset }
       }
-      if (buffer.startsWith(NARRATIVE_START)) {
-        buffer = buffer.slice(NARRATIVE_START.length)
+
+      if (startsWithFold(buffer, THINK_START)) {
+        buffer = buffer.slice(THINK_START.length)
+        inThink = true
+        requestReset()
         continue
       }
-      if (buffer.startsWith(NARRATIVE_END)) {
-        buffer = buffer.slice(NARRATIVE_END.length)
-        buffer = buffer.trimStart()
+      if (startsWithFold(buffer, THINK_END)) {
+        // MiniMax 模式：思考前言无 <think> 开始标签，到这里才闭合。
+        buffer = trimStart(buffer.slice(THINK_END.length))
+        requestReset()
+        continue
+      }
+      if (startsWithFold(buffer, NARRATIVE_START)) {
+        buffer = trimStart(buffer.slice(NARRATIVE_START.length))
+        continue
+      }
+      if (startsWithFold(buffer, NARRATIVE_END)) {
+        buffer = trimStart(buffer.slice(NARRATIVE_END.length))
         continue
       }
 
       const nextTag = findNextTag(buffer)
       if (nextTag > 0) {
         output += buffer.slice(0, nextTag)
+        emittedVisible = true
         buffer = buffer.slice(nextTag)
         continue
       }
       if (nextTag === 0) continue
 
       const keep = flushAll ? 0 : partialTagSuffixLength(buffer)
-      output += buffer.slice(0, buffer.length - keep)
+      const emit = buffer.slice(0, buffer.length - keep)
+      if (emit) {
+        output += emit
+        emittedVisible = true
+      }
       buffer = buffer.slice(buffer.length - keep)
-      return output
+      return { text: output, reset }
     }
-    return output
+    return { text: output, reset }
   }
 }
 
+/**
+ * 清洗已持久化的叙事正文，兜底历史脏数据（思考前言、</think>、<NARRATIVE> 等标签残留）。
+ * 用于渲染存档 turn.narrative，与流式过滤器对齐。
+ */
+export function sanitizeStoredNarrative(text: string): string {
+  if (!text) return text
+  let result = text
+  const open = result.search(/<\s*NARRATIVE\s*>/i)
+  if (open >= 0) {
+    // 有 <NARRATIVE> 包裹时直接取其内容，自然丢弃前面的思考前言。
+    result = result.slice(open).replace(/<\s*NARRATIVE\s*>/i, '')
+    const close = result.search(/<\s*\/\s*NARRATIVE\s*>/i)
+    if (close >= 0) result = result.slice(0, close)
+  } else {
+    // 无 <NARRATIVE>：移除配对 / 未闭合 <think>，再处理孤立 </think> 前言。
+    result = result.replace(/<think>[\s\S]*?(?:<\/think>|$)/gi, '')
+    const close = result.search(/<\s*\/\s*think\s*>/i)
+    if (close >= 0) result = result.slice(close).replace(/<\s*\/\s*think\s*>/i, '')
+  }
+  // 截断隐藏状态块及之后的内容。
+  result = result.replace(/<\s*(hot_state|state_delta)[\s\S]*$/i, '')
+  // 清理任何残留标签。
+  result = result.replace(/<\/?\s*(think|NARRATIVE)\s*>/gi, '')
+  return result.trim()
+}
+
 function findNextTag(value: string): number {
+  const lower = value.toLowerCase()
   let next = -1
-  for (const tag of VISIBLE_TAGS) {
-    const index = value.indexOf(tag)
+  for (const tag of [...VISIBLE_TAGS, ...THINK_TAGS]) {
+    const index = lower.indexOf(tag.toLowerCase())
     if (index >= 0 && (next < 0 || index < next)) next = index
   }
-  const lowerValue = value.toLowerCase()
-  const hiddenIndex = findHiddenTagIndex(lowerValue)
+  const hiddenIndex = findHiddenTagIndex(lower)
   if (hiddenIndex >= 0 && (next < 0 || hiddenIndex < next)) next = hiddenIndex
   return next
 }
@@ -90,4 +179,16 @@ function findHiddenTagIndex(value: string): number {
 
 function normalizeTagStart(value: string): string {
   return value.replace(/^<\s*/, '<')
+}
+
+function startsWithFold(value: string, prefix: string): boolean {
+  return value.slice(0, prefix.length).toLowerCase() === prefix.toLowerCase()
+}
+
+function indexOfFold(value: string, sub: string): number {
+  return value.toLowerCase().indexOf(sub.toLowerCase())
+}
+
+function trimStart(value: string): string {
+  return value.replace(/^\s+/, '')
 }


### PR DESCRIPTION
- 新增 internal/providercompat 包:为 MiniMax 等 provider 提供 工具调用文本解析、内联 think 剥离的 polyfill,以及 reasoning_split 等 provider 特有请求字段的注入入口。agent 包零 provider 知识。
- 互动叙事流式过滤器支持 <think>(含孤立 </think>)与持久化兜底
- MessageItem 兼容孤立 </think>、MiniMax 特殊 token、tool_call 残留
- 新增"正在思考"流式占位
- 修复 Vite dev server 启动(改用 vite 二进制,绕开 pnpm/msw 卡点)
- 修复状态栏硬编码"DeepSeek",改为显示实际配置模型名