### PR TITLE
Add remote access environment overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Changed
 
 - WebUI：设置页将原“模型”分区改名为“语言模型”，将原“图片 API”分区改名为“图像模型”，并从设置页移除后端/前端端口输入和访问地址端口展示；端口仍可通过环境变量或配置文件在启动时设置。
+- 配置：新增 `NOVA_ALLOW_LAN_ACCESS`、`NOVA_REMOTE_ACCESS_USERNAME` 和 `NOVA_REMOTE_ACCESS_PASSWORD_HASH` 环境变量覆盖，便于容器化部署时注入进程级远程访问配置。
 
 ### Fixed
 

--- a/config/config.go
+++ b/config/config.go
@@ -371,6 +371,17 @@ func overrideFromEnv(cfg *Config) {
 			cfg.FrontendPort = port
 		}
 	}
+	if v := os.Getenv("NOVA_ALLOW_LAN_ACCESS"); v != "" {
+		if enabled, err := strconv.ParseBool(v); err == nil {
+			cfg.AllowLANAccess = enabled
+		}
+	}
+	if v := strings.TrimSpace(os.Getenv("NOVA_REMOTE_ACCESS_USERNAME")); v != "" {
+		cfg.RemoteAccessUsername = v
+	}
+	if v := os.Getenv("NOVA_REMOTE_ACCESS_PASSWORD_HASH"); v != "" {
+		cfg.RemoteAccessPasswordHash = v
+	}
 	if v := os.Getenv("NOVA_AGENT_IDLE_TIMEOUT_SECONDS"); v != "" {
 		if seconds, err := strconv.Atoi(v); err == nil && seconds >= 0 {
 			cfg.AgentIdleTimeoutSeconds = seconds

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -247,6 +247,26 @@ func TestLoadStartupPortEnvOverridesConfig(t *testing.T) {
 	}
 }
 
+func TestLoadRemoteAccessEnvOverridesConfig(t *testing.T) {
+	root := t.TempDir()
+	t.Chdir(root)
+	t.Setenv("NOVA_DIR", "")
+	t.Setenv("NOVA_ALLOW_LAN_ACCESS", "true")
+	t.Setenv("NOVA_REMOTE_ACCESS_USERNAME", " deployer ")
+	t.Setenv("NOVA_REMOTE_ACCESS_PASSWORD_HASH", "$2y$10$hash")
+
+	cfg := Load()
+	if !cfg.AllowLANAccess {
+		t.Fatalf("NOVA_ALLOW_LAN_ACCESS should enable LAN access")
+	}
+	if cfg.RemoteAccessUsername != "deployer" {
+		t.Fatalf("remote access username = %q, want deployer", cfg.RemoteAccessUsername)
+	}
+	if cfg.RemoteAccessPasswordHash != "$2y$10$hash" {
+		t.Fatalf("remote access password hash not loaded from env")
+	}
+}
+
 func TestLoadAgentIdleTimeoutEnvAllowsZero(t *testing.T) {
 	t.Chdir(t.TempDir())
 	t.Setenv("NOVA_DIR", "")


### PR DESCRIPTION
## Summary
- Add environment variable overrides for LAN access and remote access credentials.
- Cover the new overrides in config tests.

## Tests
- docker run --rm --platform linux/arm64 --user "501:20" -v "/Users/fengzee/Developer/nova":/src -w /src -e GOCACHE=/tmp/go-cache -e GOMODCACHE=/tmp/go-mod-cache golang:1.26-bookworm bash -c 'go test ./config'