### PR TITLE
fix: 切换/创建会话不再中断正在进行的流式任务

### DIFF
--- a/web/src/hooks/useChat.ts
+++ b/web/src/hooks/useChat.ts
@@ -301,22 +301,20 @@ export function useChat(options: ChatOptions = {}) {
 
   /** 创建新会话，并刷新当前消息列表。 */
   const createChatSession = useCallback(async (title?: string) => {
-    resetStreamingState()
     const session = await createSession(title)
     setActiveSessionId(session.id)
     await Promise.all([loadSessions(), loadHistory(session.id)])
     await resumeActiveChat()
-  }, [loadHistory, loadSessions, resetStreamingState, resumeActiveChat])
+  }, [loadHistory, loadSessions, resumeActiveChat])
 
   /** 切换会话并读取该会话历史。 */
   const switchChatSession = useCallback(async (id: string) => {
     if (!id || id === activeSessionId) return
-    resetStreamingState()
     const session = await switchSession(id)
     setActiveSessionId(session.id)
     await Promise.all([loadSessions(), loadHistory(session.id)])
     await resumeActiveChat()
-  }, [activeSessionId, loadHistory, loadSessions, resetStreamingState, resumeActiveChat])
+  }, [activeSessionId, loadHistory, loadSessions, resumeActiveChat])
 
   /** 重命名会话。 */
   const renameChatSession = useCallback(async (id: string, title: string) => {


### PR DESCRIPTION
## Bug 修复

### 问题
`createChatSession` 和 `switchChatSession` 中不必要的 `resetStreamingState()` 调用，会导致用户在 Agent 流式输出过程中切换对话或创建新会话时，正在进行的任务被意外中断。

### 复现步骤
1. 在写作模式发起一个 Agent 任务（如章节生成）
2. 任务流式输出过程中，切换到另一个对话会话或创建新会话
3. 原任务被中断，流式输出停止

### 修复
移除 `createChatSession` 和 `switchChatSession` 中的 `resetStreamingState()` 调用及其依赖项。保留 `deleteChatSession` 中的调用（删除会话时确实需要重置状态）。

### 改动文件
- `web/src/hooks/useChat.ts`：移除 2 处 `resetStreamingState()` 调用，清理对应的 useCallback 依赖数组

### 验证
修复后在写作模式和互动模式中测试：流式输出过程中切换/创建会话，任务不再被中断，流式输出正常完成。