### PR TITLE
fix: 修复重建导演计划时前端崩溃 (Cannot read properties of undefined reading trim)

### DIFF
--- a/web/src/features/interactive/components/director-console/PlanView.tsx
+++ b/web/src/features/interactive/components/director-console/PlanView.tsx
@@ -103,9 +103,9 @@ export function PlanView({
         </div>
         {draftDocs ? (
           editing ? (
-            <DirectorPlanTextarea label={t('snapshot.director.plan')} value={draftDocs.plan} onChange={(value) => onDraftDocsChange({ ...draftDocs, plan: value })} />
+            <DirectorPlanTextarea label={t('snapshot.director.plan')} value={draftDocs.plan ?? ''} onChange={(value) => onDraftDocsChange({ ...draftDocs, plan: value })} />
           ) : (
-            <DirectorPlanMarkdown content={draftDocs.plan} />
+            <DirectorPlanMarkdown content={draftDocs.plan ?? ''} />
           )
         ) : (
           <div className="flex min-h-[180px] items-center justify-center rounded-[var(--nova-radius)] border border-dashed border-[var(--nova-border)] px-4 text-center text-xs text-[var(--nova-text-muted)]">{t('memoryPanel.directorEmpty')}</div>
@@ -172,7 +172,7 @@ function DirectorSpoilerGate({ onReveal }: { onReveal: () => void }) {
 
 function DirectorPlanMarkdown({ content }: { content: string }) {
   const { t } = useTranslation()
-  if (!content.trim()) {
+  if (!content?.trim()) {
     return (
       <div className="flex min-h-[180px] items-center justify-center rounded-[var(--nova-radius)] border border-dashed border-[var(--nova-border)] px-4 text-center text-xs text-[var(--nova-text-muted)]">{t('memoryPanel.plan.empty')}</div>
     )


### PR DESCRIPTION
## 问题

点击「重建导演计划」按钮时，前端白屏崩溃，控制台报错：
```
Cannot read properties of undefined (reading 'trim')
```

## 根因

`PlanView.tsx` 中 `draftDocs.plan` 在后端返回空对象（`docs: {}`，没有 `plan` 字段）时为 `undefined`，传给 `DirectorPlanMarkdown` 的 `content` 参数后，`content.trim()` 直接崩溃。

## 修复

3 处改动，共 3 行：

1. `DirectorPlanMarkdown`: `content.trim()` 改为 `content?.trim()`（安全访问）
2. `draftDocs.plan` 传给 `DirectorPlanMarkdown` 时加 `?? ''` 空值兜底
3. `draftDocs.plan` 传给 `DirectorPlanTextarea` 时加 `?? ''` 空值兜底

## 复现步骤

1. 进入游戏模式，选择一个故事
2. 打开导演控制台
3. 点击「重建导演计划」
4. 当后端返回的 `docs` 对象缺少 `plan` 字段时，前端崩溃

## 影响范围

仅修改 `PlanView.tsx` 一个文件，不影响其他组件和后端逻辑。
