### PR TITLE
Fixed a bug where documents and tables wouldn't display.

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -41,6 +41,7 @@
     "@tiptap/extension-character-count": "^3.23.2",
     "@tiptap/extension-image": "^3.23.2",
     "@tiptap/extension-placeholder": "^3.23.2",
+    "@tiptap/extension-table": "^3.23.2",
     "@tiptap/markdown": "^3.23.2",
     "@tiptap/pm": "^3.23.2",
     "@tiptap/react": "^3.23.2",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       '@tiptap/extension-placeholder':
         specifier: ^3.23.2
         version: 3.23.2(@tiptap/extensions@3.23.2(@tiptap/core@3.23.2(@tiptap/pm@3.23.2))(@tiptap/pm@3.23.2))
+      '@tiptap/extension-table':
+        specifier: ^3.23.2
+        version: 3.23.2(@tiptap/core@3.23.2(@tiptap/pm@3.23.2))(@tiptap/pm@3.23.2)
       '@tiptap/markdown':
         specifier: ^3.23.2
         version: 3.23.2(@tiptap/core@3.23.2(@tiptap/pm@3.23.2))(@tiptap/pm@3.23.2)
@@ -1886,6 +1889,12 @@ packages:
     resolution: {integrity: sha512-m1BN3EXwYagzVdReGoI7McvuZFyolFwuXLgzU6c+RN7E+u+K68EY+2U3pJI5ee8UgPYGW4eBs/3BT/5k+0so3Q==}
     peerDependencies:
       '@tiptap/core': 3.23.2
+
+  '@tiptap/extension-table@3.23.2':
+    resolution: {integrity: sha512-2+jQxxDJ/EOlUtTqaw2V9y6qBOCtFihvKCwI0Je25TBZUVJq8KcNJZt2ky0JfPC6WAQmKymEwThl3guPrSjAKg==}
+    peerDependencies:
+      '@tiptap/core': 3.23.2
+      '@tiptap/pm': 3.23.2
 
   '@tiptap/extension-text@3.23.2':
     resolution: {integrity: sha512-Ny4FC+BivfwACTuJO3QPe+BXtVFfzWQVBcfhlFlA7xTaeBktFeBavH2cEyXR8Qbez3Wio/Hn+bibT4d44EBLyg==}
@@ -5927,6 +5936,11 @@ snapshots:
   '@tiptap/extension-strike@3.23.2(@tiptap/core@3.23.2(@tiptap/pm@3.23.2))':
     dependencies:
       '@tiptap/core': 3.23.2(@tiptap/pm@3.23.2)
+
+  '@tiptap/extension-table@3.23.2(@tiptap/core@3.23.2(@tiptap/pm@3.23.2))(@tiptap/pm@3.23.2)':
+    dependencies:
+      '@tiptap/core': 3.23.2(@tiptap/pm@3.23.2)
+      '@tiptap/pm': 3.23.2
 
   '@tiptap/extension-text@3.23.2(@tiptap/core@3.23.2(@tiptap/pm@3.23.2))':
     dependencies:

--- a/web/src/components/Editor/MarkdownEditor.test.tsx
+++ b/web/src/components/Editor/MarkdownEditor.test.tsx
@@ -55,6 +55,7 @@ const tiptapMock = vi.hoisted(() => {
     editor,
     chainApi,
     handlers,
+    useEditorOptions: null as unknown,
     markdown: '',
     text: '',
     emit(event: string) {
@@ -62,6 +63,7 @@ const tiptapMock = vi.hoisted(() => {
     },
     reset() {
       handlers.clear()
+      this.useEditorOptions = null
       this.markdown = ''
       this.text = ''
       editor.state.selection = { from: 0, to: 0, head: 0, empty: true }
@@ -73,13 +75,17 @@ const tiptapMock = vi.hoisted(() => {
 
 vi.mock('@tiptap/react', () => ({
   EditorContent: () => <div data-testid="editor-content" />,
-  useEditor: () => tiptapMock.editor,
+  useEditor: (options: unknown) => {
+    tiptapMock.useEditorOptions = options
+    return tiptapMock.editor
+  },
 }))
 
 vi.mock('@tiptap/starter-kit', () => ({ default: { configure: () => ({}) } }))
 vi.mock('@tiptap/extension-character-count', () => ({ CharacterCount: { configure: () => ({}) } }))
 vi.mock('@tiptap/extension-placeholder', () => ({ default: { configure: () => ({}) } }))
 vi.mock('@tiptap/extension-image', () => ({ default: { extend: () => ({ configure: () => ({}) }) } }))
+vi.mock('@tiptap/extension-table', () => ({ TableKit: { configure: vi.fn((options) => ({ name: 'tableKit', options })) } }))
 vi.mock('@tiptap/markdown', () => ({ Markdown: { configure: () => ({}) } }))
 vi.mock('sonner', () => ({ toast: toastMock }))
 
@@ -156,6 +162,26 @@ describe('MarkdownEditor', () => {
 
     expect(onLineChange).toHaveBeenLastCalledWith(3)
     expect(document.querySelector('.nova-editor-statusbar')).not.toBeInTheDocument()
+  })
+
+  it('注册 TipTap table 扩展以展示 GFM Markdown 表格', () => {
+    render(
+      <MarkdownEditor
+        fileName="chapters/ch01.md"
+        content={'| 角色 | 状态 |\n| --- | --- |\n| 阿宁 | 待命 |'}
+        onSave={vi.fn()}
+      />,
+    )
+
+    const options = tiptapMock.useEditorOptions as { extensions?: Array<{ name?: string; options?: unknown }> }
+    expect(options.extensions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: 'tableKit',
+          options: { table: { resizable: false } },
+        }),
+      ]),
+    )
   })
 
   it('默认对白高亮跟随编辑器背景主题变化，手动颜色优先', async () => {

--- a/web/src/components/Editor/MarkdownEditor.tsx
+++ b/web/src/components/Editor/MarkdownEditor.tsx
@@ -7,6 +7,7 @@ import StarterKit from '@tiptap/starter-kit'
 import Placeholder from '@tiptap/extension-placeholder'
 import { CharacterCount } from '@tiptap/extension-character-count'
 import Image from '@tiptap/extension-image'
+import { TableKit } from '@tiptap/extension-table'
 import { Markdown } from '@tiptap/markdown'
 import type { Node as ProseMirrorNode } from '@tiptap/pm/model'
 import { Plugin, PluginKey, TextSelection as PmTextSelection } from '@tiptap/pm/state'
@@ -283,6 +284,11 @@ export function MarkdownEditor({
       searchExtension,
       dialogueHighlightExtension,
       workspaceImageExtension,
+      TableKit.configure({
+        table: {
+          resizable: false,
+        },
+      }),
       Markdown.configure({
         markedOptions: {
           gfm: true,

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -1765,6 +1765,32 @@ html[data-nova-motion="off"] *::after {
   margin: 0.6em 0;
 }
 
+.editor-content .tiptap table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 0.8em 0;
+  table-layout: fixed;
+  text-indent: 0;
+}
+
+.editor-content .tiptap th,
+.editor-content .tiptap td {
+  border: 1px solid color-mix(in srgb, var(--nova-editor-accent, #303238) 76%, transparent);
+  padding: 0.4em 0.55em;
+  vertical-align: top;
+}
+
+.editor-content .tiptap th {
+  background: color-mix(in srgb, var(--nova-editor-accent, #303238) 64%, transparent);
+  font-weight: 700;
+}
+
+.editor-content .tiptap th p,
+.editor-content .tiptap td p {
+  margin: 0;
+  text-indent: 0;
+}
+
 .editor-content .tiptap strong {
   font-weight: 700;
 }


### PR DESCRIPTION
## bug修复

### 问题
1. markdown中表格不显示；

### BUG复现步骤
1. 在md文档创建表格；
2. 表格部分未渲染。

### 修复
增加markdown中表格渲染配置

### 改动文件
- 增加“@tiptap/extension-table”依赖；
- `web/src/components/Editor/MarkdownEditor.tsx`：增加表格的渲染配置；
- `web/src/index.css`: 全局样式补充table的样式。

### 验证
修复后在md文档看到表格部分正常渲染