### PR TITLE
Specify the installation of a search tool to prevent the agent from skipping rule checks.

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -100,7 +100,7 @@ xattr -dr com.apple.quarantine denova
 
 ### Run from Source
 
-Requires Go 1.26.5+, Node.js 20+, and pnpm.
+Requires Go 1.26.5+, Node.js 20+, pnpm and ripgrep.
 
 ```bash
 git clone https://github.com/alfredxw/denova.git

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ xattr -dr com.apple.quarantine denova
 
 ### 从源码运行
 
-需要 Go 1.26.5+、Node.js 20+ 和 pnpm。
+需要 Go 1.26.5+、Node.js 20+、pnpm 和 ripgrep。
 
 ```bash
 git clone https://github.com/alfredxw/denova.git


### PR DESCRIPTION
## 功能完善

### 问题
电脑未安装ripgrep，导致agent写好文章时检查规则直接跳过，最后正文并未按照定义的规则来

### BUG复现步骤
1. 在未安装ripgrep电脑开始agent章节写作；
2. ai提示中可以看到grep工具未找到的提示；
3. 生成的章节发现许多违反规则的内容。

### 修复
标明安装ripgrep工具，官方仓库：https://github.com/burntsushi/ripgrep

### 改动文件
- README增加ripgrep工具安装提示；

### 验证
电脑安装ripgrep工具后新完成的章节验证内容符合用户定义的规则。