### PR TITLE
fix(agent): prevent malformed tool calls from freezing sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- 写作模式现在会隔离参数不是合法 JSON 的工具调用及其结果；已经保存的异常调用链也会在下次请求前被过滤，长参数则使用合法 JSON 回执保留上下文，避免会话被永久冻结。
+- Writing Mode now isolates tool calls with invalid JSON arguments and their results; previously saved malformed pairs are filtered before the next request, while large arguments use a valid JSON receipt so sessions do not become permanently frozen.
 - 设置与 Agents 的分层草稿、自动保存和输入区偏好持久化现在会串行写入，并在 revision 冲突时按原始基线重新拉取、合并和重试；卸载或过期请求不再回写状态。
 - Layered drafts in Settings and Agents, autosave, and composer preference persistence now serialize writes and refetch, rebase, and retry from the original baseline on revision conflicts; unmounted or stale requests no longer publish state.
 - 自动化后台刷新、运行结束和语言切换不再覆盖未保存任务草稿，乱序工作区响应会被忽略；窄屏操作区、资源选择器和当前项语义也保持完整可用。

--- a/internal/agent/tool_result_context.go
+++ b/internal/agent/tool_result_context.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"encoding/json"
 	"fmt"
 	"log"
 	"strings"
@@ -52,8 +53,9 @@ type toolResultContextConversation interface {
 }
 
 type toolResultContextRecorder struct {
-	conversation toolResultContextConversation
-	policy       ToolResultContextPolicy
+	conversation    toolResultContextConversation
+	policy          ToolResultContextPolicy
+	retainedCallIDs map[string]struct{}
 }
 
 func newToolResultContextRecorder(conversation Conversation) *toolResultContextRecorder {
@@ -78,17 +80,34 @@ func (r *toolResultContextRecorder) RecordAssistantToolCalls(msg *schema.Message
 	}
 	if err := r.conversation.AppendContextMessage(next); err != nil {
 		logAgentContextPersistError("assistant_tool_calls", err)
+		return
+	}
+	if r.retainedCallIDs == nil {
+		r.retainedCallIDs = make(map[string]struct{}, len(next.ToolCalls))
+	}
+	for _, call := range next.ToolCalls {
+		if callID := strings.TrimSpace(call.ID); callID != "" {
+			r.retainedCallIDs[callID] = struct{}{}
+		}
 	}
 }
 
 func (r *toolResultContextRecorder) RecordToolResult(toolName, toolCallID, content string, meta agentEventMetadata) {
-	if r == nil || r.conversation == nil || meta.SubAgent || isPlanProtocolToolName(toolName) || !retainToolContextAcrossTurns(toolName, r.policy) {
+	if r == nil || r.conversation == nil || meta.SubAgent || isPlanProtocolToolName(toolName) || !retainToolContextAcrossTurns(toolName, r.policy) || !r.retainedCall(toolCallID) {
 		return
 	}
 	msg := schema.ToolMessage(toolResultContextContent(toolName, toolCallID, content, r.policy), toolCallID, schema.WithToolName(toolName))
 	if err := r.conversation.AppendContextMessage(msg); err != nil {
 		logAgentContextPersistError("tool_result", err)
 	}
+}
+
+func (r *toolResultContextRecorder) retainedCall(toolCallID string) bool {
+	if r == nil {
+		return false
+	}
+	_, ok := r.retainedCallIDs[strings.TrimSpace(toolCallID)]
+	return ok
 }
 
 func logAgentContextPersistError(kind string, err error) {
@@ -105,19 +124,47 @@ func assistantToolContextMessage(msg *schema.Message, policy ToolResultContextPo
 			continue
 		}
 		next := call
-		next.Function.Arguments = limitContextText(next.Function.Arguments, policy.PreviewChars, fmt.Sprintf(
-			"\n[Denova tool call args truncated for context]\ntool_name: %s\ntool_call_id: %s\noriginal_chars: %d\npreview_chars: %d",
-			next.Function.Name,
-			next.ID,
-			countRunes(next.Function.Arguments),
-			policy.PreviewChars,
-		))
+		arguments, valid := retainedToolCallArguments(next.Function.Arguments, next.Function.Name, next.ID, policy.PreviewChars)
+		if !valid {
+			continue
+		}
+		next.Function.Arguments = arguments
 		calls = append(calls, next)
 	}
 	if len(calls) == 0 {
 		return nil
 	}
 	return schema.AssistantMessage("", calls)
+}
+
+func retainedToolCallArguments(arguments, toolName, toolCallID string, previewChars int) (string, bool) {
+	arguments = strings.TrimSpace(arguments)
+	if err := validateToolArgumentsJSON(arguments); err != nil {
+		return "", false
+	}
+	if arguments == "" {
+		return "{}", true
+	}
+	if previewChars <= 0 || countRunes(arguments) <= previewChars {
+		return arguments, true
+	}
+	receipt, err := json.Marshal(struct {
+		Schema        string `json:"schema"`
+		ToolName      string `json:"tool_name"`
+		ToolCallID    string `json:"tool_call_id"`
+		OriginalChars int    `json:"original_chars"`
+		Note          string `json:"note"`
+	}{
+		Schema:        "tool_call.args_omitted.v1",
+		ToolName:      strings.TrimSpace(toolName),
+		ToolCallID:    strings.TrimSpace(toolCallID),
+		OriginalChars: countRunes(arguments),
+		Note:          "Original tool arguments were omitted from retained context. Re-run the tool if exact arguments are required.",
+	})
+	if err != nil {
+		return "", false
+	}
+	return string(receipt), true
 }
 
 func toolResultContextContent(toolName, toolCallID, content string, policy ToolResultContextPolicy) string {

--- a/internal/agent/tool_result_context_semantic.go
+++ b/internal/agent/tool_result_context_semantic.go
@@ -115,9 +115,10 @@ func appendUniqueRetainedValue(values []string, value string) []string {
 
 func filterSemanticToolContextMessages(messages []*schema.Message, policy ToolResultContextPolicy) []*schema.Message {
 	type retainedCall struct {
-		toolName string
-		retain   bool
-		valid    bool
+		toolName  string
+		arguments string
+		retain    bool
+		valid     bool
 	}
 	callsByID := make(map[string]retainedCall)
 	resultCountsByID := make(map[string]int)
@@ -137,10 +138,12 @@ func filterSemanticToolContextMessages(messages []*schema.Message, policy ToolRe
 					callsByID[callID] = existing
 					continue
 				}
+				arguments, valid := retainedToolCallArguments(call.Function.Arguments, toolName, callID, policy.PreviewChars)
 				callsByID[callID] = retainedCall{
-					toolName: toolName,
-					retain:   retainToolContextAcrossTurns(toolName, policy),
-					valid:    true,
+					toolName:  toolName,
+					arguments: arguments,
+					retain:    retainToolContextAcrossTurns(toolName, policy),
+					valid:     valid,
 				}
 			}
 			continue
@@ -172,7 +175,7 @@ func filterSemanticToolContextMessages(messages []*schema.Message, policy ToolRe
 				if callID == "" || !knownCall || !callPolicy.valid || resultCountsByID[callID] != 1 || !callPolicy.retain {
 					continue
 				}
-				call.Function.Arguments = limitContextText(call.Function.Arguments, policy.PreviewChars, "\n[Denova tool call args truncated for retained context]")
+				call.Function.Arguments = callPolicy.arguments
 				next.ToolCalls = append(next.ToolCalls, call)
 			}
 			if len(next.ToolCalls) > 0 || strings.TrimSpace(next.Content) != "" {

--- a/internal/agent/tool_result_context_test.go
+++ b/internal/agent/tool_result_context_test.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 
@@ -88,11 +89,83 @@ func TestToolResultContextRecorderBoundsLargeResults(t *testing.T) {
 		Type: "function",
 		Function: schema.FunctionCall{
 			Name:      "write_file",
-			Arguments: strings.Repeat("x", 20),
+			Arguments: `{"content":"` + strings.Repeat("x", 20) + `"}`,
 		},
 	}}), ToolResultContextPolicy{PreviewChars: 6})
-	if call == nil || len(call.ToolCalls) != 1 || !strings.Contains(call.ToolCalls[0].Function.Arguments, "tool call args truncated") {
-		t.Fatalf("large tool args should be bounded: %#v", call)
+	if call == nil || len(call.ToolCalls) != 1 || !strings.Contains(call.ToolCalls[0].Function.Arguments, "tool_call.args_omitted.v1") {
+		t.Fatalf("large tool args should be replaced with a valid receipt: %#v", call)
+	}
+	if err := validateToolArgumentsJSON(call.ToolCalls[0].Function.Arguments); err != nil {
+		t.Fatalf("retained tool arguments must stay valid JSON: %v", err)
+	}
+}
+
+func TestToolResultContextRecorderSkipsMalformedCallAndResult(t *testing.T) {
+	conversation := &recordedToolContextConversation{
+		policy: ToolResultContextPolicy{Enabled: true, PreviewChars: 100},
+	}
+	recorder := newToolResultContextRecorder(conversation)
+	recorder.RecordAssistantToolCalls(schema.AssistantMessage("", []schema.ToolCall{{
+		ID:   "call-invalid",
+		Type: "function",
+		Function: schema.FunctionCall{
+			Name:      "write_file",
+			Arguments: `{"content":`,
+		},
+	}}), agentEventMetadata{})
+	recorder.RecordToolResult("write_file", "call-invalid", "invalid arguments", agentEventMetadata{})
+
+	if len(conversation.messages) != 0 {
+		t.Fatalf("malformed tool call and result must not persist into future context: %#v", conversation.messages)
+	}
+}
+
+func TestApplyToolResultContextPolicyDropsMalformedLegacyToolPair(t *testing.T) {
+	messages := []*schema.Message{
+		schema.AssistantMessage("", []schema.ToolCall{{
+			ID:   "call-invalid",
+			Type: "function",
+			Function: schema.FunctionCall{
+				Name:      "read_file",
+				Arguments: `{"path":`,
+			},
+		}}),
+		schema.ToolMessage("invalid arguments", "call-invalid", schema.WithToolName("read_file")),
+		schema.UserMessage("继续"),
+	}
+
+	filtered := applyToolResultContextPolicy(messages, ToolResultContextPolicy{Enabled: true, BudgetBytes: 1024, PreviewChars: 100})
+	if len(filtered) != 1 || filtered[0].Role != schema.User || filtered[0].Content != "继续" {
+		t.Fatalf("legacy malformed tool pair must be excluded from the next request: %#v", filtered)
+	}
+}
+
+func TestApplyToolResultContextPolicyUsesValidArgumentsReceipt(t *testing.T) {
+	messages := []*schema.Message{
+		schema.AssistantMessage("", []schema.ToolCall{{
+			ID:   "call-large",
+			Type: "function",
+			Function: schema.FunctionCall{
+				Name:      "read_file",
+				Arguments: `{"path":"` + strings.Repeat("a", 100) + `"}`,
+			},
+		}}),
+		schema.ToolMessage("content", "call-large", schema.WithToolName("read_file")),
+	}
+
+	filtered := applyToolResultContextPolicy(messages, ToolResultContextPolicy{Enabled: true, BudgetBytes: 1024, PreviewChars: 20})
+	if len(filtered) != 2 || len(filtered[0].ToolCalls) != 1 {
+		t.Fatalf("large retained tool pair should remain available: %#v", filtered)
+	}
+	arguments := filtered[0].ToolCalls[0].Function.Arguments
+	if err := validateToolArgumentsJSON(arguments); err != nil {
+		t.Fatalf("retained arguments must be valid JSON: %v", err)
+	}
+	var receipt struct {
+		Schema string `json:"schema"`
+	}
+	if err := json.Unmarshal([]byte(arguments), &receipt); err != nil || receipt.Schema != "tool_call.args_omitted.v1" {
+		t.Fatalf("expected a retained arguments receipt, got %q err=%v", arguments, err)
 	}
 }
 
@@ -223,4 +296,19 @@ func TestToolResultContextKeepsLoreErrorsInsteadOfPositiveReceipt(t *testing.T) 
 	if content != raw {
 		t.Fatalf("failed reads should remain an error instead of becoming a receipt: %q", content)
 	}
+}
+
+type recordedToolContextConversation struct {
+	Conversation
+	messages []*schema.Message
+	policy   ToolResultContextPolicy
+}
+
+func (c *recordedToolContextConversation) AppendContextMessage(msg *schema.Message) error {
+	c.messages = append(c.messages, msg)
+	return nil
+}
+
+func (c *recordedToolContextConversation) ToolResultContextPolicy() ToolResultContextPolicy {
+	return c.policy
 }


### PR DESCRIPTION
## Summary
- retain only tool calls whose arguments are valid JSON and retain their results only as paired context
- replace oversized retained arguments with a valid JSON receipt instead of truncating JSON
- filter malformed legacy tool call/result pairs before the next model request

## Validation
- `go test ./internal/agent`
- `go test ./...`

Fixes #55