### PR TITLE
fix(agent): avoid mid-cutting JSON tool result previews

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- 修复 Agent `prefill failed: unexpected control character ... char 2000`：JSON 形态 tool result 不再按默认 2000 字硬截断并拼接换行 marker。
+- Fixed Agent `prefill failed: unexpected control character ... char 2000`: stop mid-cutting JSON tool results at the default 2000-rune preview with a newline marker.
+
 - 写作模式现在会隔离参数不是合法 JSON 的工具调用及其结果；已经保存的异常调用链也会在下次请求前被过滤，长参数则使用合法 JSON 回执保留上下文，避免会话被永久冻结。
 - Writing Mode now isolates tool calls with invalid JSON arguments and their results; previously saved malformed pairs are filtered before the next request, while large arguments use a valid JSON receipt so sessions do not become permanently frozen.
 - 设置与 Agents 的分层草稿、自动保存和输入区偏好持久化现在会串行写入，并在 revision 冲突时按原始基线重新拉取、合并和重试；卸载或过期请求不再回写状态。

--- a/internal/agent/tool_result_context.go
+++ b/internal/agent/tool_result_context.go
@@ -174,6 +174,14 @@ func toolResultContextContent(toolName, toolCallID, content string, policy ToolR
 	if content == "" {
 		content = "(无返回内容)"
 	}
+	// JSON bodies must not be mid-cut at PreviewChars (default 2000): the "\n..."
+	// marker makes providers that re-parse tool content fail with
+	// "unexpected control character ... char 2000".
+	if policy.PreviewChars > 0 && countRunes(content) > policy.PreviewChars && looksLikeJSONPayload(content) {
+		return toolResultPlaceholderMessage(&schema.Message{
+			Role: schema.Tool, Content: content, ToolName: toolName, ToolCallID: toolCallID,
+		}, "tool_result_json_preview_exceeded").Content
+	}
 	return limitContextText(content, policy.PreviewChars, fmt.Sprintf(
 		"\n[Denova tool result preview truncated for context]\ntool_name: %s\ntool_call_id: %s\noriginal_chars: %d\npreview_chars: %d",
 		toolName,
@@ -208,6 +216,11 @@ func limitContextText(content string, maxRunes int, marker string) string {
 		return content
 	}
 	return strings.TrimRight(string(runes[:maxRunes]), "\n") + marker
+}
+
+func looksLikeJSONPayload(content string) bool {
+	content = strings.TrimSpace(content)
+	return strings.HasPrefix(content, "{") || strings.HasPrefix(content, "[")
 }
 
 func applyToolResultContextPolicy(messages []*schema.Message, policy ToolResultContextPolicy) []*schema.Message {

--- a/internal/agent/tool_result_context_test.go
+++ b/internal/agent/tool_result_context_test.go
@@ -298,6 +298,21 @@ func TestToolResultContextKeepsLoreErrorsInsteadOfPositiveReceipt(t *testing.T) 
 	}
 }
 
+func TestToolResultContextContentDoesNotMidCutJSON(t *testing.T) {
+	raw, err := json.Marshal(map[string]any{"items": strings.Repeat("修炼境界寿元设定", 500)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	content := toolResultContextContent("write_file", "call-json", string(raw), ToolResultContextPolicy{PreviewChars: 2000})
+	if strings.Contains(content, "preview truncated for context") {
+		t.Fatalf("must not mid-cut JSON tool bodies: %s", content)
+	}
+	if !strings.Contains(content, "tool_result_json_preview_exceeded") {
+		t.Fatalf("oversized JSON should become placeholder: %s", content)
+	}
+}
+
+
 type recordedToolContextConversation struct {
 	Conversation
 	messages []*schema.Message


### PR DESCRIPTION
<img width="730" height="125" alt="image" src="https://github.com/user-attachments/assets/f07dde12-1a03-4181-afaf-c1d9005bf4d7" />
<img width="604" height="164" alt="image" src="https://github.com/user-attachments/assets/5da2cd06-fb1a-4fea-a3d9-256708259b1a" />

在微信交流群看到群友的求助之后找他要到了日志：
[2026-07-21.log](https://github.com/user-attachments/files/30225734/2026-07-21.log)

和 grok 先生狠狠的分析了一通之后发现问题其实出在项目内原有的对工具输出自动截断的设计上，现有的第2000字符截断的设计过于简单粗暴，只是直接在第2000个字符不管三七二十一打断然后填上: 
``` plaintext
{...前2000字符的JSON内容...
[Denova tool result preview truncated for context]
tool_name: file_read
tool_call_id: xxx
original_chars: 8500
preview_chars: 2000
```

### 这导致了什么问题？

well，本来这应该只是用来省点上下文窗口的设计，也不应该出问题，但是似乎供应商在 prefill 的时候把上下文里面的工具调用结果又拿回去解析成json了，这最终导致出现了日志中的如下错误，并且出现了整整三次：

`prefill failed: unexpected control character ... char 2000`

那么为什么压缩了上下文就可以解决这个问题呢？当然是因为被压缩之后不成形的工具调用本身没有了，这样供应商的prefill自然就不会有问题了......

### 怎么修复？

很简单，在截断的地方加一个判断，如果工具调用结果超长了那么就把整段工具调用结果都变成占位符：

```go
if policy.PreviewChars > 0 && countRunes(content) > policy.PreviewChars && looksLikeJSONPayload(content) {
    return toolResultPlaceholderMessage(...)  // 整体替换为占位符
}
```

此时，工具调用结果被替换成合法的纯文本，当然也不会触发prefill流程里面的json解析问题。

虽然这样看起来是丢失了工具调用的部分信息，但是实际上被截断了的工具调用信息本身也没那么那么有实际意义，不如llm自己再去调用一次。

（反正是都命中不到缓存了）

After seeing a group member's request for help in the WeChat group chat, I asked them for the log file:

[2026-07-21.log](https://github.com/user-attachments/files/30225734/2026-07-21.log)

After an in-depth analysis with Mr. Grok, we found that the root cause lies in the original design of automatic truncation for tool outputs within the project. The existing truncation logic that cuts off content at the 2000th character is overly crude; it simply slices the text abruptly at the 2000th character and appends the following content:


```plaintext
{...the first 2000 characters of JSON content...
[Denova tool result preview truncated for context]
tool_name: file_read
tool_call_id: xxx
original_chars: 8500
preview_chars: 2000

```
### What problems does this cause?

Originally, this design was only meant to save context window space and should not have caused errors. However, it appears that during prefill processing, the vendor parses the tool call results stored in the context back into JSON. This ultimately triggers the following error recorded in the log, which occurred a total of three times:

`prefill failed: unexpected control character ... char 2000`

So why does compressing the context resolve this issue? Naturally, compression removes the malformed truncated tool call segments, eliminating the parsing failures in the vendor's prefill process......

### How to fix it?

The solution is straightforward: add a conditional check at the truncation step. If a tool call result exceeds the character limit, replace the entire tool call output with a placeholder:

```go
if policy.PreviewChars > 0 && countRunes(content) > policy.PreviewChars && looksLikeJSONPayload(content) {
    return toolResultPlaceholderMessage(...)  // Replace the entire content with a placeholder
}
```
With this change, tool call outputs are replaced with valid plain text, which avoids the JSON parsing error in the prefill workflow entirely.

While this seems to discard partial tool call information, the truncated fragments carry little practical value anyway—it is more efficient to let the LLM re-invoke the tool itself.

(The truncated content cannot hit the cache in any case.)