### PR TITLE
fix: batch streaming chunk updates to prevent UI jank in long convers…

### DIFF
--- a/web/src/hooks/useAgentSSEUIMessageStream.ts
+++ b/web/src/hooks/useAgentSSEUIMessageStream.ts
@@ -10,6 +10,25 @@ interface AgentSSEUIMessageStreamOptions {
 
 type AgentMessageUpdater = SetStateAction<AgentUIMessage[]>
 
+/** A buffered streaming text chunk awaiting rAF flush. */
+interface PendingTextChunk {
+  segmentIDRef: { current: string }
+  partType: 'text' | 'reasoning'
+  content: string
+  metadata?: AgentMessageMetadata
+}
+
+/** A buffered tool args delta awaiting rAF flush. */
+interface PendingToolArgsDelta {
+  toolID: string
+  data: Record<string, unknown>
+  metadata: AgentMessageMetadata
+}
+
+type PendingChunk =
+  | { kind: 'text'; chunk: PendingTextChunk }
+  | { kind: 'tool_args'; delta: PendingToolArgsDelta }
+
 export function useAgentSSEUIMessageStream(options: AgentSSEUIMessageStreamOptions = {}) {
   const { t } = useTranslation()
   const { onEvent } = options
@@ -21,6 +40,9 @@ export function useAgentSSEUIMessageStream(options: AgentSSEUIMessageStreamOptio
   const reasoningSegmentIDRef = useRef('')
   const toolInputsRef = useRef<Record<string, string>>({})
   const toolCounterRef = useRef(0)
+  // rAF batch buffer: streaming deltas are queued here and flushed once per frame.
+  const pendingChunksRef = useRef<PendingChunk[]>([])
+  const rafRef = useRef<number>(0)
 
   const setMessages = useCallback((updater: AgentMessageUpdater) => {
     rawSetMessages((current) => {
@@ -31,12 +53,48 @@ export function useAgentSSEUIMessageStream(options: AgentSSEUIMessageStreamOptio
     })
   }, []) as Dispatch<SetStateAction<AgentUIMessage[]>>
 
+  /** Flush all buffered streaming chunks into a single setState (no normalization). */
+  const flushPendingChunks = useCallback(() => {
+    if (rafRef.current) {
+      cancelAnimationFrame(rafRef.current)
+      rafRef.current = 0
+    }
+    const pending = pendingChunksRef.current
+    if (pending.length === 0) return
+    pendingChunksRef.current = []
+    rawSetMessages(current => {
+      let next = current
+      for (const entry of pending) {
+        if (entry.kind === 'text') {
+          next = applyTextChunk(next, entry.chunk)
+        } else {
+          next = applyToolArgsDelta(next, entry.delta, toolInputsRef)
+        }
+      }
+      return next
+    })
+  }, [])
+
+  /** Schedule a rAF flush if one is not already pending. */
+  const scheduleFlush = useCallback(() => {
+    if (rafRef.current) return
+    rafRef.current = requestAnimationFrame(() => {
+      rafRef.current = 0
+      flushPendingChunks()
+    })
+  }, [flushPendingChunks])
+
   const resetStreamingState = useCallback(() => {
     abortControllerRef.current?.abort()
     abortControllerRef.current = null
     textSegmentIDRef.current = ''
     reasoningSegmentIDRef.current = ''
     toolInputsRef.current = {}
+    if (rafRef.current) {
+      cancelAnimationFrame(rafRef.current)
+      rafRef.current = 0
+    }
+    pendingChunksRef.current = []
     setIsStreaming(false)
     setActivityContent('')
   }, [])
@@ -53,6 +111,7 @@ export function useAgentSSEUIMessageStream(options: AgentSSEUIMessageStreamOptio
     textSegmentIDRef.current = ''
     reasoningSegmentIDRef.current = ''
     toolInputsRef.current = {}
+    pendingChunksRef.current = []
     setIsStreaming(true)
     setActivityContent(t('chat.activity.thinking'))
     try {
@@ -65,34 +124,56 @@ export function useAgentSSEUIMessageStream(options: AgentSSEUIMessageStreamOptio
         const metadata = readEventMetadata(data)
         onEvent?.(event, data)
         switch (event.event) {
-          case 'chunk':
-            appendStreamingText(rawSetMessages, textSegmentIDRef, 'text', readString(data.content), metadata)
+          case 'chunk': {
+            const content = readString(data.content)
+            if (content) {
+              pendingChunksRef.current.push({ kind: 'text', chunk: { segmentIDRef: textSegmentIDRef, partType: 'text', content, metadata } })
+              scheduleFlush()
+            }
             setActivityContent('')
             break
-          case 'thinking':
-            appendStreamingText(rawSetMessages, reasoningSegmentIDRef, 'reasoning', readString(data.content), metadata)
+          }
+          case 'thinking': {
+            const content = readString(data.content)
+            if (content) {
+              pendingChunksRef.current.push({ kind: 'text', chunk: { segmentIDRef: reasoningSegmentIDRef, partType: 'reasoning', content, metadata } })
+              scheduleFlush()
+            }
             setActivityContent(t('chat.activity.thinking'))
             break
+          }
           case 'tool_call':
+            flushPendingChunks()
             upsertTool(rawSetMessages, toolInputsRef, toolCounterRef, data, metadata, 'input-available')
             setActivityContent('')
             break
-          case 'tool_args_delta':
-            appendToolArgs(rawSetMessages, toolInputsRef, toolCounterRef, data, metadata)
+          case 'tool_args_delta': {
+            const toolID = toolEventID(data, toolCounterRef)
+            const delta = readString(data.delta)
+            if (delta) {
+              toolInputsRef.current[toolID] = `${toolInputsRef.current[toolID] || ''}${delta}`
+              pendingChunksRef.current.push({ kind: 'tool_args', delta: { toolID, data, metadata } })
+              scheduleFlush()
+            }
             break
+          }
           case 'tool_result':
+            flushPendingChunks()
             upsertTool(rawSetMessages, toolInputsRef, toolCounterRef, data, metadata, data.status === 'error' ? 'output-error' : 'output-available')
             setActivityContent('')
             break
           case 'done':
+            flushPendingChunks()
             finishStreamingParts(rawSetMessages)
             setActivityContent('')
             break
           case 'aborted':
+            flushPendingChunks()
             finishStreamingParts(rawSetMessages)
             setActivityContent(t('chat.activity.aborted'))
             break
           case 'error':
+            flushPendingChunks()
             finishStreamingParts(rawSetMessages)
             setMessages(prev => [...prev, createAgentDataMessage('agent-error', { content: readString(data.message) || readString(data.error) || t('chat.activity.unknownError') })])
             setActivityContent('')
@@ -102,8 +183,10 @@ export function useAgentSSEUIMessageStream(options: AgentSSEUIMessageStreamOptio
             break
         }
       }
+      flushPendingChunks()
       finishStreamingParts(rawSetMessages)
     } catch (error) {
+      flushPendingChunks()
       finishStreamingParts(rawSetMessages)
       if (isAbortError(error)) {
         setActivityContent(t('chat.activity.aborted'))
@@ -111,6 +194,11 @@ export function useAgentSSEUIMessageStream(options: AgentSSEUIMessageStreamOptio
         setMessages(prev => [...prev, createAgentDataMessage('agent-error', { content: t('chat.activity.requestFailed', { error: String(error) }) })])
       }
     } finally {
+      if (rafRef.current) {
+        cancelAnimationFrame(rafRef.current)
+        rafRef.current = 0
+      }
+      pendingChunksRef.current = []
       abortControllerRef.current = null
       textSegmentIDRef.current = ''
       reasoningSegmentIDRef.current = ''
@@ -118,7 +206,7 @@ export function useAgentSSEUIMessageStream(options: AgentSSEUIMessageStreamOptio
       setIsStreaming(false)
       setActivityContent('')
     }
-  }, [onEvent, setMessages, t])
+  }, [onEvent, setMessages, t, flushPendingChunks, scheduleFlush])
 
   return {
     messages,
@@ -132,29 +220,26 @@ export function useAgentSSEUIMessageStream(options: AgentSSEUIMessageStreamOptio
   }
 }
 
-function appendStreamingText(
-  setMessages: Dispatch<SetStateAction<AgentUIMessage[]>>,
-  segmentIDRef: { current: string },
-  partType: 'text' | 'reasoning',
-  content: string,
-  metadata?: AgentMessageMetadata,
-) {
-  if (!content) return
+/**
+ * Apply a buffered text chunk to the message array without normalization.
+ * First chunk for a segment creates a new message; subsequent chunks append text.
+ */
+function applyTextChunk(messages: AgentUIMessage[], chunk: PendingTextChunk): AgentUIMessage[] {
+  const { segmentIDRef, partType, content, metadata } = chunk
   if (!segmentIDRef.current) {
     segmentIDRef.current = localSSEMessageID(partType)
     const part = partType === 'text'
       ? { type: 'text', text: content, state: 'streaming' }
       : { type: 'reasoning', text: content, state: 'streaming' }
-    setMessages(current => normalizeAgentUIMessages([...current, {
+    return [...messages, {
       id: segmentIDRef.current,
       role: 'assistant',
       metadata,
       parts: [part],
-    } as AgentUIMessage]))
-    return
+    } as AgentUIMessage]
   }
   const messageID = segmentIDRef.current
-  setMessages(current => normalizeAgentUIMessages(current.map((message) => {
+  return messages.map((message) => {
     if (message.id !== messageID) return message
     return {
       ...message,
@@ -165,7 +250,34 @@ function appendStreamingText(
         return { ...raw, text: `${readString(raw.text)}${content}`, state: 'streaming' } as AgentUIMessage['parts'][number]
       }),
     } as AgentUIMessage
-  })))
+  })
+}
+
+/**
+ * Apply a buffered tool args delta by upserting the tool card without normalization.
+ */
+function applyToolArgsDelta(
+  messages: AgentUIMessage[],
+  delta: PendingToolArgsDelta,
+  toolInputsRef: { current: Record<string, string> },
+): AgentUIMessage[] {
+  const { toolID, data, metadata } = delta
+  const toolName = readString(data.name) || 'unknown_tool'
+  const inputText = toolInputsRef.current[toolID] || ''
+  const part: Record<string, unknown> = {
+    type: 'dynamic-tool',
+    toolName,
+    toolCallId: toolID,
+    state: 'input-streaming',
+    input: parseJSONValue(inputText),
+    providerMetadata: { agent: metadata },
+  }
+  return upsertAgentMessage(messages, {
+    id: toolID,
+    role: 'assistant',
+    metadata,
+    parts: [part as AgentUIMessage['parts'][number]],
+  } as AgentUIMessage)
 }
 
 function upsertTool(
@@ -200,19 +312,6 @@ function upsertTool(
   } as AgentUIMessage)))
 }
 
-function appendToolArgs(
-  setMessages: Dispatch<SetStateAction<AgentUIMessage[]>>,
-  toolInputsRef: { current: Record<string, string> },
-  counterRef: { current: number },
-  data: Record<string, unknown>,
-  metadata: AgentMessageMetadata,
-) {
-  const toolID = toolEventID(data, counterRef)
-  const delta = readString(data.delta)
-  if (!delta) return
-  toolInputsRef.current[toolID] = `${toolInputsRef.current[toolID] || ''}${delta}`
-  upsertTool(setMessages, toolInputsRef, counterRef, data, metadata, 'input-streaming')
-}
 
 function finishStreamingParts(setMessages: Dispatch<SetStateAction<AgentUIMessage[]>>) {
   setMessages(current => normalizeAgentUIMessages(current.map((message) => ({


### PR DESCRIPTION
对 `useAgentSSEUIMessageStream` 钩子进行大规模重构，用以提升界面渲染性能，减少智能体消息流式更新过程中不必要的重复渲染。核心改动是针对流式文本与工具参数增量数据引入 requestAnimationFrame（rAF）批处理机制，保证界面更新每帧最多执行一次。同时新增并重构若干工具函数，支撑这套全新的缓冲方案。

**性能与流式更新优化：**
* 新增内存缓冲类型（`PendingTextChunk`、`PendingToolArgsDelta`、`PendingChunk`）以及基于 rAF 的批处理机制（`pendingChunksRef`、`rafRef`、`flushPendingChunks`、`scheduleFlush`），实现流式消息更新的排队与批量推送。该方案取代原先逐个数据块立即更新状态的方式，降低界面重复渲染次数。[[1]](diffhunk://#diff-5a3ce7c3f67e4b841e17474f6d189505a1a8744bc5ca1953613f0b9fb637c81eR13-R31) [[2]](diffhunk://#diff-5a3ce7c3f67e4b841e17474f6d189505a1a8744bc5ca1953613f0b9fb637c81eR43-R45) [[3]](diffhunk://#diff-5a3ce7c3f67e4b841e17474f6d189505a1a8744bc5ca1953613f0b9fb637c81eR56-R97)
* 更新事件处理逻辑，对 `chunk`、`thinking`、`tool_args_delta` 事件进行缓冲，安排统一推送时机，不再立刻更新状态。工具调用与结束类事件（`tool_call`、`tool_result`、`done`、`aborted`、`error`）会强制触发缓冲区推送，确保界面状态在后续逻辑执行前保持最新。[[1]](diffhunk://#diff-5a3ce7c3f67e4b841e17474f6d189505a1a8744bc5ca1953613f0b9fb637c81eL68-R176) [[2]](diffhunk://#diff-5a3ce7c3f67e4b841e17474f6d189505a1a8744bc5ca1953613f0b9fb637c81eR114) [[3]](diffhunk://#diff-5a3ce7c3f67e4b841e17474f6d189505a1a8744bc5ca1953613f0b9fb637c81eR186-R209)

**代码简化与重构工作：**
* 使用全新纯函数（`applyTextChunk`、`applyToolArgsDelta`）替换旧的 `appendStreamingText` 和 `appendToolArgs` 函数。新函数直接将缓冲的数据块作用于消息数组，跳过标准化流程，适配新的批处理逻辑。[[1]](diffhunk://#diff-5a3ce7c3f67e4b841e17474f6d189505a1a8744bc5ca1953613f0b9fb637c81eL135-R242) [[2]](diffhunk://#diff-5a3ce7c3f67e4b841e17474f6d189505a1a8744bc5ca1953613f0b9fb637c81eL168-R280) [[3]](diffhunk://#diff-5a3ce7c3f67e4b841e17474f6d189505a1a8744bc5ca1953613f0b9fb637c81eL203-L215)
* 梳理并统一流式状态的重置与清理逻辑，保证数据流结束、发生异常或中断时，所有缓冲区与动画帧任务能够被妥善清除。[[1]](diffhunk://#diff-5a3ce7c3f67e4b841e17474f6d189505a1a8744bc5ca1953613f0b9fb637c81eR56-R97) [[2]](diffhunk://#diff-5a3ce7c3f67e4b841e17474f6d189505a1a8744bc5ca1953613f0b9fb637c81eR186-R209)

以上改动能够让聊天界面在高频流式数据推送场景下响应更流畅、性能更佳。

这个修复是对 Issue #56 修复的一部分。

This pull request significantly refactors the `useAgentSSEUIMessageStream` hook to improve UI performance and reduce unnecessary re-renders during streaming agent message updates. The main change is the introduction of a requestAnimationFrame (rAF) batching mechanism for streaming text and tool argument deltas, ensuring updates are flushed to the UI at most once per frame. Several helper functions are added or refactored to support this new buffering approach.

**Performance and Streaming Update Improvements:**

* Added new in-memory buffer types (`PendingTextChunk`, `PendingToolArgsDelta`, and `PendingChunk`) and a rAF-based batching mechanism (`pendingChunksRef`, `rafRef`, `flushPendingChunks`, `scheduleFlush`) to queue and flush streaming message updates efficiently. This replaces immediate per-chunk state updates with batched updates, reducing UI re-renders. [[1]](diffhunk://#diff-5a3ce7c3f67e4b841e17474f6d189505a1a8744bc5ca1953613f0b9fb637c81eR13-R31) [[2]](diffhunk://#diff-5a3ce7c3f67e4b841e17474f6d189505a1a8744bc5ca1953613f0b9fb637c81eR43-R45) [[3]](diffhunk://#diff-5a3ce7c3f67e4b841e17474f6d189505a1a8744bc5ca1953613f0b9fb637c81eR56-R97)

* Updated the event processing logic to buffer `'chunk'`, `'thinking'`, and `'tool_args_delta'` events, scheduling a flush instead of updating state immediately. Tool and completion events (`'tool_call'`, `'tool_result'`, `'done'`, `'aborted'`, `'error'`) now force a flush to ensure the UI is up-to-date before processing further. [[1]](diffhunk://#diff-5a3ce7c3f67e4b841e17474f6d189505a1a8744bc5ca1953613f0b9fb637c81eL68-R176) [[2]](diffhunk://#diff-5a3ce7c3f67e4b841e17474f6d189505a1a8744bc5ca1953613f0b9fb637c81eR114) [[3]](diffhunk://#diff-5a3ce7c3f67e4b841e17474f6d189505a1a8744bc5ca1953613f0b9fb637c81eR186-R209)

**Codebase Simplification and Refactoring:**

* Replaced the old `appendStreamingText` and `appendToolArgs` functions with new pure functions (`applyTextChunk`, `applyToolArgsDelta`) that apply buffered chunks to the message array without normalization, supporting the new batching logic. [[1]](diffhunk://#diff-5a3ce7c3f67e4b841e17474f6d189505a1a8744bc5ca1953613f0b9fb637c81eL135-R242) [[2]](diffhunk://#diff-5a3ce7c3f67e4b841e17474f6d189505a1a8744bc5ca1953613f0b9fb637c81eL168-R280) [[3]](diffhunk://#diff-5a3ce7c3f67e4b841e17474f6d189505a1a8744bc5ca1953613f0b9fb637c81eL203-L215)

* Cleaned up and centralized streaming state reset and cleanup logic to ensure all buffers and animation frames are properly cleared on stream end, error, or abort. [[1]](diffhunk://#diff-5a3ce7c3f67e4b841e17474f6d189505a1a8744bc5ca1953613f0b9fb637c81eR56-R97) [[2]](diffhunk://#diff-5a3ce7c3f67e4b841e17474f6d189505a1a8744bc5ca1953613f0b9fb637c81eR186-R209)

These changes should make the chat UI more responsive and performant during high-frequency streaming updates.

This fix is part of the resolution for Issue #56.