### PR TITLE
Refine character image prompts before generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- 资料库角色图片在调用图像模型前，先通过图像 Agent 所配置的语言模型提炼角色设定，只保留外貌、性格、服装配饰和其他可视特点；最终图片 Prompt 不再包含原始角色正文或“角色资料卡”字样。
+- Lore character images now pass character lore through the Image Agent's configured language model before image generation, retaining only appearance, personality, attire/accessories, and other visual traits. The final image prompt no longer includes raw character lore or the “角色资料卡” label.
+
 ## [v0.3.2] - 2026-07-23
 
 ### Changed

--- a/internal/api/handler_lore_image_test.go
+++ b/internal/api/handler_lore_image_test.go
@@ -97,27 +97,63 @@ func TestLoreImagesGenerateStreamSkipsExistingByDefault(t *testing.T) {
 
 func newLoreImageTestApplication(t *testing.T) (*runtimeapp.App, *httptest.Server) {
 	t.Helper()
-	var calls int
+	var imageCalls int
 	imageServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		calls++
-		if r.URL.Path != "/images/generations" {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/chat/completions":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id":      "chatcmpl-character-traits",
+				"object":  "chat.completion",
+				"created": 123,
+				"model":   "test-model",
+				"choices": []map[string]any{{
+					"index": 0,
+					"message": map[string]any{
+						"role":    "assistant",
+						"content": `{"appearance":"黑色短发，灰色眼睛","personality":"谨慎沉静","attire_accessories":"深色风衣","other_visual_traits":""}`,
+					},
+					"finish_reason": "stop",
+				}},
+			})
+		case "/images/generations":
+			imageCalls++
+			var body map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatal(err)
+			}
+			prompt, _ := body["prompt"].(string)
+			if strings.Contains(prompt, "资料类型：角色") {
+				for _, want := range []string{"黑色短发", "谨慎沉静", "深色风衣"} {
+					if !strings.Contains(prompt, want) {
+						t.Fatalf("character image prompt missing refined trait %q: %s", want, prompt)
+					}
+				}
+				for _, forbidden := range []string{"角色资料卡", "谨慎。"} {
+					if strings.Contains(prompt, forbidden) {
+						t.Fatalf("character image prompt leaked raw lore %q: %s", forbidden, prompt)
+					}
+				}
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"created":       123,
+				"output_format": "png",
+				"quality":       "high",
+				"size":          "2048x2048",
+				"data": []map[string]any{{
+					"b64_json":       base64.StdEncoding.EncodeToString(loreImageTestPNGBytes()),
+					"revised_prompt": "revised prompt",
+				}},
+			})
+		default:
 			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(map[string]any{
-			"created":       123,
-			"output_format": "png",
-			"quality":       "high",
-			"size":          "2048x2048",
-			"data": []map[string]any{{
-				"b64_json":       base64.StdEncoding.EncodeToString(loreImageTestPNGBytes()),
-				"revised_prompt": "revised prompt",
-			}},
-		})
 	}))
 	root := t.TempDir()
 	application, err := runtimeapp.New(context.Background(), &config.Config{
 		OpenAIModel:         "test-model",
+		OpenAIAPIKey:        "test-key",
+		OpenAIBaseURL:       imageServer.URL,
 		NovaDir:             root,
 		Workspace:           root,
 		ResumeLastWorkspace: false,
@@ -130,7 +166,7 @@ func newLoreImageTestApplication(t *testing.T) (*runtimeapp.App, *httptest.Serve
 		t.Fatal(err)
 	}
 	t.Cleanup(func() {
-		if calls == 0 {
+		if imageCalls == 0 {
 			t.Fatalf("image server was not called")
 		}
 	})

--- a/internal/loreimage/character_refiner.go
+++ b/internal/loreimage/character_refiner.go
@@ -1,0 +1,178 @@
+package loreimage
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/cloudwego/eino-ext/components/model/openai"
+	"github.com/cloudwego/eino/schema"
+
+	"denova/config"
+	"denova/internal/book"
+	"denova/internal/providercompat"
+)
+
+const characterSourceMaxChars = 6000
+
+type modelCharacterTraitsRefiner struct{}
+
+type characterTraitsInput struct {
+	Name             string   `json:"name"`
+	Tags             []string `json:"tags,omitempty"`
+	Keywords         []string `json:"keywords,omitempty"`
+	BriefDescription string   `json:"brief_description,omitempty"`
+	Content          string   `json:"content,omitempty"`
+}
+
+type characterTraitsPayload struct {
+	Appearance        string `json:"appearance"`
+	Personality       string `json:"personality"`
+	AttireAccessories string `json:"attire_accessories"`
+	OtherVisualTraits string `json:"other_visual_traits"`
+}
+
+func newModelCharacterTraitsRefiner() characterTraitsRefiner {
+	return modelCharacterTraitsRefiner{}
+}
+
+func (modelCharacterTraitsRefiner) Refine(ctx context.Context, cfg *config.Config, item book.LoreItem) (string, error) {
+	if cfg == nil {
+		return "", fmt.Errorf("运行配置不可用")
+	}
+	input := characterTraitsInput{
+		Name:             strings.TrimSpace(item.Name),
+		Tags:             item.Tags,
+		Keywords:         item.Keywords,
+		BriefDescription: trimRunes(item.BriefDescription, maxBriefChars),
+		Content:          trimRunes(item.Content, maxContentChars),
+	}
+	data, err := json.Marshal(input)
+	if err != nil {
+		return "", err
+	}
+	if len([]rune(string(data))) > characterSourceMaxChars {
+		return "", fmt.Errorf("角色设定超过 %d 字符上限", characterSourceMaxChars)
+	}
+
+	modelCfg := characterRefinerModelConfig(cfg)
+	modelCfg.ResponseFormat = &openai.ChatCompletionResponseFormat{
+		Type: openai.ChatCompletionResponseFormatTypeJSONObject,
+	}
+	log.Printf("[lore-image] character traits refinement begin item_id=%s model=%q", item.ID, modelCfg.Model)
+	content, err := generateCharacterTraits(ctx, modelCfg, string(data))
+	if err != nil {
+		if ctx.Err() != nil {
+			return "", err
+		}
+		log.Printf("[lore-image] character traits json mode failed item_id=%s err=%v; retrying plain mode", item.ID, err)
+		modelCfg.ResponseFormat = nil
+		content, err = generateCharacterTraits(ctx, modelCfg, string(data))
+	}
+	if err != nil {
+		return "", err
+	}
+	traits, err := parseCharacterTraits(content)
+	if err != nil {
+		return "", err
+	}
+	log.Printf("[lore-image] character traits refinement done item_id=%s chars=%d", item.ID, len([]rune(traits)))
+	return traits, nil
+}
+
+func characterRefinerModelConfig(cfg *config.Config) openai.ChatModelConfig {
+	resolved := config.ResolveAgentModel(cfg, config.AgentKindImage)
+	modelCfg := openai.ChatModelConfig{
+		APIKey:     resolved.OpenAIAPIKey,
+		Model:      resolved.OpenAIModel,
+		BaseURL:    resolved.OpenAIBaseURL,
+		HTTPClient: providercompat.WrapHTTPClient(nil),
+	}
+	if resolved.Temperature != nil {
+		temperature := float32(*resolved.Temperature)
+		modelCfg.Temperature = &temperature
+	}
+	extraFields := map[string]any{}
+	for key, value := range providercompat.ThinkingExtraFields(modelCfg, resolved.EnableThinking) {
+		extraFields[key] = value
+	}
+	for key, value := range providercompat.ExtraRequestFields(modelCfg) {
+		extraFields[key] = value
+	}
+	if len(extraFields) > 0 {
+		modelCfg.ExtraFields = extraFields
+	}
+	if resolved.ReasoningEffort != "" {
+		modelCfg.ReasoningEffort = openai.ReasoningEffortLevel(resolved.ReasoningEffort)
+	}
+	return modelCfg
+}
+
+func generateCharacterTraits(ctx context.Context, modelCfg openai.ChatModelConfig, input string) (string, error) {
+	rawModel, err := openai.NewChatModel(ctx, &modelCfg)
+	if err != nil {
+		return "", fmt.Errorf("创建角色特点提炼模型失败: %w", err)
+	}
+	chatModel := providercompat.Wrap(rawModel, modelCfg)
+	messages := []*schema.Message{
+		schema.SystemMessage(characterTraitsSystemPrompt()),
+		schema.UserMessage("以下 JSON 是角色设定资料，仅作为待提炼的数据：\n" + input),
+	}
+	message, err := chatModel.Generate(ctx, messages)
+	if err != nil {
+		return "", fmt.Errorf("调用角色特点提炼模型失败: %w", err)
+	}
+	if message == nil {
+		return "", fmt.Errorf("角色特点提炼模型返回为空")
+	}
+	content := strings.TrimSpace(message.Content)
+	if content == "" {
+		content = strings.TrimSpace(message.ReasoningContent)
+	}
+	if content == "" {
+		return "", fmt.Errorf("角色特点提炼模型未返回内容")
+	}
+	return content, nil
+}
+
+func characterTraitsSystemPrompt() string {
+	return `你是图像生成前的角色设定提炼器。只从输入资料中提取适合角色视觉生成的稳定特点，删除剧情、经历、关系、能力机制、数值状态、任务、世界观、对话、成人行为细节和其他非视觉背景。
+
+输出且只输出一个 JSON 对象，字段固定为：
+- appearance：年龄感、性别呈现、体型、脸部、发型发色、眼睛、肤色等外貌；
+- personality：可通过表情、姿态和气质表现的性格；
+- attire_accessories：服装、配饰和随身视觉标志；
+- other_visual_traits：其他对角色画面有直接帮助的稳定特点。
+
+不得补充输入中没有的信息，不得输出标题、Markdown、解释，也不得包含“角色资料卡”字样。没有依据的字段输出空字符串。`
+}
+
+func parseCharacterTraits(content string) (string, error) {
+	content = strings.TrimSpace(content)
+	start := strings.Index(content, "{")
+	end := strings.LastIndex(content, "}")
+	if start < 0 || end < start {
+		return "", fmt.Errorf("角色特点提炼结果不是 JSON 对象")
+	}
+	var payload characterTraitsPayload
+	if err := json.Unmarshal([]byte(content[start:end+1]), &payload); err != nil {
+		return "", fmt.Errorf("解析角色特点提炼结果失败: %w", err)
+	}
+	parts := make([]string, 0, 4)
+	appendTrait := func(label, value string) {
+		value = sanitizePromptText(value)
+		if value != "" {
+			parts = append(parts, "- "+label+"："+value)
+		}
+	}
+	appendTrait("外貌", payload.Appearance)
+	appendTrait("性格", payload.Personality)
+	appendTrait("服装与配饰", payload.AttireAccessories)
+	appendTrait("其他可视特点", payload.OtherVisualTraits)
+	if len(parts) == 0 {
+		return "", fmt.Errorf("角色特点提炼结果没有可用内容")
+	}
+	return trimRunes(strings.Join(parts, "\n"), maxCharacterTraits), nil
+}

--- a/internal/loreimage/service.go
+++ b/internal/loreimage/service.go
@@ -25,14 +25,20 @@ const (
 	maxBriefChars       = 1000
 	maxContentChars     = 4000
 	maxInstructionChars = 1000
+	maxCharacterTraits  = 2000
 )
 
 type ImageGenerator interface {
 	Generate(ctx context.Context, cfg *config.Config, request imagegen.GenerateRequest) (imagegen.Result, error)
 }
 
+type characterTraitsRefiner interface {
+	Refine(ctx context.Context, cfg *config.Config, item book.LoreItem) (string, error)
+}
+
 type Service struct {
 	generator ImageGenerator
+	refiner   characterTraitsRefiner
 	now       func() time.Time
 	suffix    func() string
 }
@@ -46,6 +52,7 @@ type GenerateRequest struct {
 	Size              string
 	Quality           string
 	OutputFormat      string
+	characterTraits   string
 }
 
 type Meta struct {
@@ -73,12 +80,17 @@ type Meta struct {
 }
 
 func NewService() *Service {
-	return NewServiceWithGenerator(imagegen.NewService())
+	return newServiceWithDependencies(imagegen.NewService(), newModelCharacterTraitsRefiner())
 }
 
 func NewServiceWithGenerator(generator ImageGenerator) *Service {
+	return newServiceWithDependencies(generator, newModelCharacterTraitsRefiner())
+}
+
+func newServiceWithDependencies(generator ImageGenerator, refiner characterTraitsRefiner) *Service {
 	return &Service{
 		generator: generator,
+		refiner:   refiner,
 		now:       time.Now,
 		suffix:    randomSuffix,
 	}
@@ -103,6 +115,16 @@ func (s *Service) Generate(ctx context.Context, cfg *config.Config, bookService 
 	}
 	if strings.TrimSpace(item.Name) == "" {
 		return book.LoreItemImage{}, fmt.Errorf("资料名称不能为空")
+	}
+	if isCharacterItem(item) {
+		if s.refiner == nil {
+			return book.LoreItemImage{}, fmt.Errorf("角色图片提示词提炼器不可用")
+		}
+		traits, err := s.refiner.Refine(ctx, cfg, item)
+		if err != nil {
+			return book.LoreItemImage{}, fmt.Errorf("提炼角色图片特点失败: %w", err)
+		}
+		request.characterTraits = traits
 	}
 	prompt := BuildPrompt(request)
 	if prompt == "" {
@@ -201,10 +223,11 @@ func (s *Service) Generate(ctx context.Context, cfg *config.Config, bookService 
 
 func BuildPrompt(request GenerateRequest) string {
 	item := request.Item
-	preset := trimRunes(request.ImagePresetPrompt, maxPresetChars)
+	preset := sanitizePromptText(trimRunes(request.ImagePresetPrompt, maxPresetChars))
 	brief := trimRunes(item.BriefDescription, maxBriefChars)
 	content := trimRunes(item.Content, maxContentChars)
-	instruction := trimRunes(request.Instruction, maxInstructionChars)
+	instruction := sanitizePromptText(trimRunes(request.Instruction, maxInstructionChars))
+	characterTraits := sanitizePromptText(trimRunes(request.characterTraits, maxCharacterTraits))
 	var sb strings.Builder
 	if preset != "" {
 		sb.WriteString("# 图像风格要求\n\n")
@@ -212,31 +235,47 @@ func BuildPrompt(request GenerateRequest) string {
 		sb.WriteString("\n\n")
 	}
 	sb.WriteString("# 本次资料项图片请求\n\n")
-	sb.WriteString("为资料库条目生成一张可作为设定卡片预览和创作参考的视觉图。画面应突出主体、身份或规则意象，适合在资料库列表中识别；不要生成任何文字、标题、作者名、水印、logo、UI 面板或二维码。\n\n")
+	sb.WriteString("为资料库条目生成一张可作为设定预览和创作参考的视觉图。画面应突出主体、身份或规则意象，适合在资料库列表中识别；不要生成任何文字、标题、作者名、水印、logo、UI 面板或二维码。\n\n")
 	writePromptLine(&sb, "资料类型", loreTypeLabel(item.Type))
 	writePromptLine(&sb, "资料名称", item.Name)
-	if len(item.Tags) > 0 {
-		writePromptLine(&sb, "标签", strings.Join(item.Tags, "、"))
-	}
-	if len(item.Keywords) > 0 {
-		writePromptLine(&sb, "关键词", strings.Join(item.Keywords, "、"))
-	}
-	if brief != "" {
-		sb.WriteString("\n## 简介\n\n")
-		sb.WriteString(brief)
-		sb.WriteString("\n")
-	}
-	if content != "" {
-		sb.WriteString("\n## 资料正文节选\n\n")
-		sb.WriteString(content)
-		sb.WriteString("\n")
+	if isCharacterItem(item) {
+		if characterTraits != "" {
+			sb.WriteString("\n## 角色特点\n\n")
+			sb.WriteString(characterTraits)
+			sb.WriteString("\n")
+		}
+	} else {
+		if len(item.Tags) > 0 {
+			writePromptLine(&sb, "标签", strings.Join(item.Tags, "、"))
+		}
+		if len(item.Keywords) > 0 {
+			writePromptLine(&sb, "关键词", strings.Join(item.Keywords, "、"))
+		}
+		if brief != "" {
+			sb.WriteString("\n## 简介\n\n")
+			sb.WriteString(brief)
+			sb.WriteString("\n")
+		}
+		if content != "" {
+			sb.WriteString("\n## 资料正文节选\n\n")
+			sb.WriteString(content)
+			sb.WriteString("\n")
+		}
 	}
 	if instruction != "" {
 		sb.WriteString("\n## 用户补充要求\n\n")
 		sb.WriteString(instruction)
 		sb.WriteString("\n")
 	}
-	return strings.TrimSpace(sb.String())
+	return sanitizePromptText(strings.TrimSpace(sb.String()))
+}
+
+func isCharacterItem(item book.LoreItem) bool {
+	return strings.EqualFold(strings.TrimSpace(item.Type), "character")
+}
+
+func sanitizePromptText(value string) string {
+	return strings.TrimSpace(strings.ReplaceAll(value, "角色资料卡", ""))
 }
 
 func writePromptLine(sb *strings.Builder, key, value string) {

--- a/internal/loreimage/service_test.go
+++ b/internal/loreimage/service_test.go
@@ -24,7 +24,8 @@ func TestGenerateSavesLoreImageAndMetadata(t *testing.T) {
 		OutputFormat: "png",
 		Images:       []imagegen.Image{{Data: []byte("image"), Extension: "png", MIMEType: "image/png", RevisedPrompt: "revised"}},
 	}}
-	service := NewServiceWithGenerator(generator)
+	refiner := &fakeCharacterTraitsRefiner{traits: "- 外貌：黑发灰眼，身形修长\n- 性格：谨慎沉静"}
+	service := newServiceWithDependencies(generator, refiner)
 	service.now = func() time.Time { return time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC) }
 	service.suffix = func() string { return "abcd1234" }
 
@@ -35,7 +36,7 @@ func TestGenerateSavesLoreImageAndMetadata(t *testing.T) {
 			Name:             "林川",
 			Tags:             []string{"主角"},
 			BriefDescription: "角色 林川。谨慎。",
-			Content:          "## 林川\n\n谨慎而疲惫。",
+			Content:          "# 角色资料卡\n\n曾在旧城追查失踪案件。",
 		},
 		Instruction:       "夜色氛围",
 		ImagePresetID:     "game-cg",
@@ -62,6 +63,14 @@ func TestGenerateSavesLoreImageAndMetadata(t *testing.T) {
 	}
 	if !strings.Contains(generator.request.Prompt, "电影感光影") || !strings.Contains(generator.request.Prompt, "夜色氛围") || !strings.Contains(generator.request.Prompt, "林川") {
 		t.Fatalf("prompt missing expected context:\n%s", generator.request.Prompt)
+	}
+	if refiner.item.ID != "hero" || !strings.Contains(generator.request.Prompt, "黑发灰眼") || !strings.Contains(generator.request.Prompt, "谨慎沉静") {
+		t.Fatalf("character traits were not refined into image prompt:\n%s", generator.request.Prompt)
+	}
+	for _, forbidden := range []string{"角色资料卡", "旧城", "失踪案件", "主角"} {
+		if strings.Contains(generator.request.Prompt, forbidden) {
+			t.Fatalf("character prompt leaked raw lore %q:\n%s", forbidden, generator.request.Prompt)
+		}
 	}
 }
 
@@ -99,7 +108,7 @@ func TestGenerateStopsBeforeWritingWhenContextCanceledAfterModel(t *testing.T) {
 			Images:       []imagegen.Image{{Data: []byte("image"), Extension: "png", MIMEType: "image/png"}},
 		},
 	}
-	service := NewServiceWithGenerator(generator)
+	service := newServiceWithDependencies(generator, &fakeCharacterTraitsRefiner{traits: "- 外貌：黑发"})
 
 	_, err := service.Generate(ctx, &config.Config{}, book.NewService(workspace), GenerateRequest{
 		Item: book.LoreItem{
@@ -117,11 +126,89 @@ func TestGenerateStopsBeforeWritingWhenContextCanceledAfterModel(t *testing.T) {
 	}
 }
 
+func TestGenerateStopsBeforeImageModelWhenCharacterRefinementFails(t *testing.T) {
+	generator := &fakeImageGenerator{}
+	service := newServiceWithDependencies(generator, &fakeCharacterTraitsRefiner{err: errors.New("model unavailable")})
+
+	_, err := service.Generate(context.Background(), &config.Config{}, book.NewService(t.TempDir()), GenerateRequest{
+		Item: book.LoreItem{
+			ID:      "hero",
+			Type:    "character",
+			Name:    "林川",
+			Content: "角色资料卡：主角经历。",
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "提炼角色图片特点失败") {
+		t.Fatalf("Generate error = %v", err)
+	}
+	if generator.request.Prompt != "" {
+		t.Fatalf("image model should not run after refinement failure: %#v", generator.request)
+	}
+}
+
+func TestBuildPromptUsesOnlyRefinedTraitsForCharacterLore(t *testing.T) {
+	prompt := BuildPrompt(GenerateRequest{
+		Item: book.LoreItem{
+			Type:             "character",
+			Name:             "沈凝",
+			Tags:             []string{"反派"},
+			Keywords:         []string{"秘密组织"},
+			BriefDescription: "角色资料卡：组织首领。",
+			Content:          "她计划夺取王位，并与主角存在宿怨。",
+		},
+		characterTraits: "- 外貌：银色长发，蓝灰色眼睛\n- 性格：冷静克制\n角色资料卡",
+	})
+	for _, want := range []string{"资料名称：沈凝", "银色长发", "冷静克制"} {
+		if !strings.Contains(prompt, want) {
+			t.Fatalf("prompt missing %q:\n%s", want, prompt)
+		}
+	}
+	for _, forbidden := range []string{"角色资料卡", "组织首领", "秘密组织", "夺取王位", "主角", "反派"} {
+		if strings.Contains(prompt, forbidden) {
+			t.Fatalf("prompt contains unfiltered character lore %q:\n%s", forbidden, prompt)
+		}
+	}
+}
+
+func TestParseCharacterTraitsKeepsVisualFieldsAndRemovesCardLabel(t *testing.T) {
+	traits, err := parseCharacterTraits(`{
+		"appearance":"角色资料卡：二十岁，黑色短发，琥珀色眼睛",
+		"personality":"外冷内热，神情克制",
+		"attire_accessories":"深色风衣，银色耳钉",
+		"other_visual_traits":"站姿挺拔"
+	}`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"外貌：", "黑色短发", "性格：", "外冷内热", "服装与配饰：", "银色耳钉", "其他可视特点：", "站姿挺拔"} {
+		if !strings.Contains(traits, want) {
+			t.Fatalf("traits missing %q:\n%s", want, traits)
+		}
+	}
+	if strings.Contains(traits, "角色资料卡") {
+		t.Fatalf("traits retained forbidden label:\n%s", traits)
+	}
+}
+
 type fakeImageGenerator struct {
 	request imagegen.GenerateRequest
 	result  imagegen.Result
 	err     error
 	cancel  context.CancelFunc
+}
+
+type fakeCharacterTraitsRefiner struct {
+	item   book.LoreItem
+	traits string
+	err    error
+}
+
+func (f *fakeCharacterTraitsRefiner) Refine(_ context.Context, _ *config.Config, item book.LoreItem) (string, error) {
+	f.item = item
+	if f.err != nil {
+		return "", f.err
+	}
+	return f.traits, nil
 }
 
 func (f *fakeImageGenerator) Generate(ctx context.Context, cfg *config.Config, request imagegen.GenerateRequest) (imagegen.Result, error) {


### PR DESCRIPTION
## What changed

- Run character lore through the configured Image Agent language model before calling the image model.
- Keep only appearance, visually expressible personality, attire/accessories, and other stable visual traits.
- Remove raw character lore, tags, keywords, and the `角色资料卡` label from the final image prompt.
- Stop image generation when character-trait refinement fails instead of falling back to unfiltered lore.
- Add unit and API integration coverage for prompt filtering and the text-model-to-image-model call sequence.

## Why

Character lore was previously appended directly to image prompts. That leaked card headings and non-visual story details into the image request, reducing prompt quality and making generated character images less focused.

## User impact

Lore character images now use a concise visual description derived from the configured Image Agent model. Non-character lore image generation remains unchanged.

## Validation

- `go test ./...`
- `go vet ./...`
- `go mod tidy -diff`
- `git diff --check`
- `./scripts/build.sh`
- Local runtime health checks for `/` and `/api/status` returned HTTP 200.
