### PR TITLE
Fix CI pnpm version mismatch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 10
+          version: 11.15.1
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/web/package.json
+++ b/web/package.json
@@ -2,6 +2,7 @@
   "name": "web",
   "private": true,
   "version": "0.3.3",
+  "packageManager": "pnpm@11.15.1",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
- pin CI to pnpm 11.15.1, matching the committed lockfile
- declare the same package manager version for local reproducibility

## Verification
- frozen dependency install with pnpm 11.15.1
- 257 frontend test files / 1613 tests
- TypeScript and production frontend build